### PR TITLE
Refine portfolio case study detail pages

### DIFF
--- a/src/components/case-study/ArchitectureDiagram.vue
+++ b/src/components/case-study/ArchitectureDiagram.vue
@@ -6,29 +6,29 @@
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">client</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Browser</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">interactive map view</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Interactive map view</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">frontend</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">React 18</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">shadcn/ui + Tailwind CSS</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">UI components + styling</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">map</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Leaflet</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">auto-fitting bounds</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Auto-fitting map bounds</p>
         </div>
       </div>
       <div class="grid grid-cols-2 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">services</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Pure Functions</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">filtering, pricing, XSS protection</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Filtering, pricing, security logic</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">resilience</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Portal Modals</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">z-index isolation + image fallback</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Layered popups + image fallbacks</p>
         </div>
       </div>
       <div class="bg-cream-100 dark:bg-charcoal-50 p-3 border-t border-cobalt-500/10 dark:border-charcoal-200/30 text-center">
@@ -42,33 +42,33 @@
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">frontend</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Nuxt 3</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">Pinia + Shadcn/Vue + layers</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Vue framework + state management</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">auth</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Firebase</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">email + Google OAuth → JWT</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Email + Google login</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">payments</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Stripe</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">cards, credit, bank, COD</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Cards, bank transfer, cash on delivery</p>
         </div>
       </div>
       <div class="grid grid-cols-2 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">api layer</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">HttpFactory</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">17 services, generic call&lt;T&gt;</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Reusable API service pattern</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">security</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Error Sanitizer</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">masks secrets in console + UI</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Hides sensitive data from errors</p>
         </div>
       </div>
       <div class="bg-cream-100 dark:bg-charcoal-50 p-3 border-t border-cobalt-500/10 dark:border-charcoal-200/30 text-center">
-        <p class="text-xs font-mono text-cobalt-500/40 dark:text-cobalt-300/40">74 granular permissions + mock payment mode</p>
+        <p class="text-xs font-mono text-cobalt-500/40 dark:text-cobalt-300/40">74 permission levels + safe test payments</p>
       </div>
     </template>
 
@@ -78,34 +78,34 @@
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">components</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">React 19</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">Radix UI primitives</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Accessible UI building blocks</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">catalog</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Storybook 10</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">Chromatic + a11y addon</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Visual component documentation</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">i18n</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">i18next</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">multi-language stories</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Multi-language story support</p>
         </div>
       </div>
       <div class="grid grid-cols-3 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">types</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Discriminated Unions</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">variant-based rendering</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Type-safe component variants</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">layout</p>
-          <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">useDynamicMaxHeight</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">responsive sidebar pipeline</p>
+          <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Dynamic Height Hook</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Responsive sidebar sizing</p>
         </div>
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">safety</p>
-          <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Fearless Refactoring</p>
-          <p class="text-xs text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">type-safe story contracts</p>
+          <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Type-safe Stories</p>
+          <p class="text-xs text-cobalt-500/70 dark:text-cobalt-300/70 mt-1">Catch errors before production</p>
         </div>
       </div>
       <div class="bg-cream-100 dark:bg-charcoal-50 p-3 border-t border-cobalt-500/10 dark:border-charcoal-200/30 text-center">

--- a/src/components/case-study/CaseStudyHero.vue
+++ b/src/components/case-study/CaseStudyHero.vue
@@ -1,18 +1,16 @@
 <template>
-  <section ref="heroRef" class="relative min-h-[70vh] flex items-center bg-cobalt-700 overflow-hidden">
-    <!-- Background decoration -->
-    <div class="absolute inset-0">
-      <div data-depth="3" class="absolute top-1/4 -right-20 w-96 h-96 bg-cobalt-500 rounded-full opacity-10 animate-float"></div>
-      <div data-depth="2" class="absolute bottom-1/4 -left-20 w-80 h-80 bg-cobalt-400 rounded-full opacity-10 animate-float animation-delay-200"></div>
-      <div data-depth="1" class="absolute top-1/2 left-1/2 w-64 h-64 bg-cobalt-400 rounded-full opacity-5 animate-pulse-slow"></div>
-      <div data-depth="2" class="absolute inset-0 opacity-5" style="background-image: radial-gradient(circle at 1px 1px, white 1px, transparent 0); background-size: 40px 40px;"></div>
-    </div>
+  <section ref="heroRef" class="relative flex items-center bg-cobalt-700 overflow-hidden">
+    <!-- Terminal-style grid background -->
+    <div class="absolute inset-0 opacity-[0.07]" style="background-image: linear-gradient(white 1px, transparent 1px), linear-gradient(90deg, white 1px, transparent 1px); background-size: 48px 48px;"></div>
+    <div class="absolute top-0 left-0 right-0 h-px bg-white/10"></div>
+    <div class="absolute bottom-0 left-0 right-0 h-px bg-white/10"></div>
 
-    <div class="relative max-w-6xl mx-auto px-6 lg:px-8 py-32 w-full">
+    <div class="relative max-w-6xl mx-auto px-6 lg:px-8 py-24 w-full">
       <div class="max-w-3xl">
-        <!-- Category badge -->
-        <div class="inline-block px-3 py-1 bg-white/10 rounded-lg text-cream-200 text-xs font-semibold mb-6 backdrop-filter backdrop-blur-sm">
-          {{ category }}
+        <!-- Terminal prompt prefix -->
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-cobalt-400 font-mono text-xs">$</span>
+          <span class="text-cream-300/60 font-mono text-xs">cat {{ category.toLowerCase().replace(/\s+/g, '-') }}.md</span>
         </div>
 
         <!-- Title -->
@@ -21,43 +19,21 @@
         </h1>
 
         <!-- Tagline -->
-        <p class="text-xl text-gray-300 mb-8 max-w-xl leading-relaxed">{{ tagline }}</p>
+        <p class="text-xl text-cream-300/80 mb-10 max-w-xl leading-relaxed">{{ tagline }}</p>
 
-        <!-- Metaphor Banner -->
-        <MetaphorBanner
-          :phrase="metaphor.phrase"
-          :description="metaphor.description"
-          :icon="metaphor.icon"
-        />
-
-        <!-- Meta row -->
-        <div class="flex flex-wrap gap-6 mt-8 text-sm">
-          <div class="flex items-center gap-2 text-gray-300">
-            <svg class="w-4 h-4 text-cobalt-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            {{ duration }}
-          </div>
-          <div class="flex items-center gap-2 text-gray-300">
-            <svg class="w-4 h-4 text-cobalt-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-            </svg>
-            {{ role }}
-          </div>
-          <div class="flex items-center gap-2 text-gray-300">
-            <svg class="w-4 h-4 text-cobalt-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-            </svg>
-            {{ year }}
-          </div>
+        <!-- Meta row — compact horizontal strip -->
+        <div class="flex flex-wrap gap-x-8 gap-y-2 text-sm text-cream-300/60 font-mono border-t border-white/10 pt-4">
+          <span>{{ duration }}</span>
+          <span>{{ role }}</span>
+          <span>{{ year }}</span>
         </div>
 
         <!-- Tech badges -->
-        <div class="flex flex-wrap gap-2 mt-6">
+        <div class="flex flex-wrap gap-2 mt-4">
           <span
             v-for="t in tech"
             :key="t"
-            class="px-3 py-1.5 bg-white bg-opacity-10 rounded-lg text-white text-sm font-medium border border-white border-opacity-10"
+            class="px-2.5 py-1 bg-white/5 text-cream-200/80 text-xs font-mono border border-white/10"
           >
             {{ t }}
           </span>
@@ -70,13 +46,13 @@
             :href="github"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 px-6 py-3 bg-white bg-opacity-10 text-white rounded-xl hover:bg-opacity-20 transition-all duration-200 font-semibold text-sm border border-white border-opacity-20 ripple-container"
+            class="inline-flex items-center gap-2 px-4 py-2 bg-white/5 text-cream-200 text-sm font-mono border border-white/10 hover:bg-white/10 transition-colors duration-200"
             data-cursor="button"
           >
-            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
             </svg>
-            View Source Code
+            view source
           </a>
         </div>
       </div>
@@ -86,20 +62,14 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, PropType } from 'vue'
-import { ProjectMetaphor } from '../../types/projects'
-import { useParallaxDepth } from '../../composables/useParallaxDepth'
 import { useMagneticEffect } from '../../composables/useMagneticEffect'
-import { useRipple } from '../../composables/useRipple'
-import MetaphorBanner from './MetaphorBanner.vue'
 
 export default defineComponent({
   name: 'CaseStudyHero',
-  components: { MetaphorBanner },
   props: {
     title: { type: String, required: true },
     category: { type: String, required: true },
     tagline: { type: String, required: true },
-    metaphor: { type: Object as PropType<ProjectMetaphor>, required: true },
     tech: { type: Array as PropType<string[]>, required: true },
     duration: { type: String, required: true },
     role: { type: String, required: true },
@@ -107,17 +77,8 @@ export default defineComponent({
     github: { type: String, default: undefined },
   },
   setup() {
-    const { containerRef: heroRef } = useParallaxDepth({ intensity: 15 })
     const { magneticRef: githubRef } = useMagneticEffect({ strength: 0.25, radius: 120 })
-    const ripple = useRipple()
-
-    onMounted(() => {
-      if (githubRef.value) {
-        ripple.rippleRef.value = githubRef.value
-      }
-    })
-
-    return { heroRef, githubRef }
+    return { heroRef: githubRef, githubRef }
   },
 })
 </script>

--- a/src/components/case-study/CaseStudyHero.vue
+++ b/src/components/case-study/CaseStudyHero.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, PropType } from 'vue'
+import { defineComponent, ref, PropType } from 'vue'
 import { useMagneticEffect } from '../../composables/useMagneticEffect'
 
 export default defineComponent({
@@ -77,8 +77,9 @@ export default defineComponent({
     github: { type: String, default: undefined },
   },
   setup() {
+    const heroRef = ref<HTMLElement | null>(null)
     const { magneticRef: githubRef } = useMagneticEffect({ strength: 0.25, radius: 120 })
-    return { heroRef: githubRef, githubRef }
+    return { heroRef, githubRef }
   },
 })
 </script>

--- a/src/components/case-study/JourneyTimeline.vue
+++ b/src/components/case-study/JourneyTimeline.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="py-12">
     <div class="mb-10">
-      <h2 class="text-3xl md:text-4xl font-display text-cobalt-500 dark:text-cobalt-300 mb-4">The Journey</h2>
-      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">How this project unfolded, step by step</p>
+      <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-2">### journey</h2>
+      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">How this project unfolded</p>
     </div>
 
     <div ref="containerRef" class="space-y-0">

--- a/src/components/case-study/OutcomesGrid.vue
+++ b/src/components/case-study/OutcomesGrid.vue
@@ -1,49 +1,33 @@
 <template>
-  <section class="py-12">
-    <div class="mb-12">
-      <h2 class="text-3xl md:text-4xl font-display text-cobalt-500 dark:text-cobalt-300 mb-4">The Impact</h2>
-      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">Measurable results from the project</p>
+  <section>
+    <div class="mb-10">
+      <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-2">### impact</h2>
+      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">Measurable results</p>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
-      <div
-        v-for="(outcome, i) in outcomes"
-        :key="outcome.label"
-        :ref="el => { if (el) outcomeRefs[i] = el }"
-        class="relative p-8 border border-cobalt-500/20 dark:border-charcoal-200/40 bg-cream-100 dark:bg-charcoal-50 reveal group"
-        :class="{ revealed: outcomeVisibility[i] }"
-        :style="{ transitionDelay: (i * 150) + 'ms' }"
-      >
-        <!-- Top accent line -->
-        <div class="absolute top-0 left-0 right-0 h-1 bg-cobalt-500/20 dark:bg-cobalt-300/20 group-hover:bg-cobalt-500/60 dark:group-hover:bg-cobalt-300/60 transition-colors duration-300" aria-hidden="true"></div>
+    <!-- Horizontal metrics strip -->
+    <div
+      v-for="(outcome, i) in outcomes"
+      :key="outcome.label"
+      :ref="el => { if (el) outcomeRefs[i] = el }"
+      class="flex items-baseline gap-6 py-4 border-b border-cobalt-500/10 dark:border-charcoal-200/20 reveal group last:border-b-0"
+      :class="{ revealed: outcomeVisibility[i] }"
+      :style="{ transitionDelay: (i * 100) + 'ms' }"
+    >
+      <!-- Index -->
+      <span class="text-xs font-mono text-cobalt-500/30 dark:text-cobalt-300/30 w-6 shrink-0 tabular-nums">
+        {{ String(i + 1).padStart(2, '0') }}
+      </span>
 
-        <!-- Corner index number -->
-        <span class="absolute top-3 right-4 text-xs font-mono text-cobalt-500/30 dark:text-cobalt-300/30" aria-hidden="true">
-          {{ String(i + 1).padStart(2, '0') }}
-        </span>
+      <!-- Metric -->
+      <span class="text-2xl md:text-3xl font-display font-bold text-cobalt-500 dark:text-cobalt-300 shrink-0 tabular-nums w-24 md:w-32">
+        {{ outcome.metric }}
+      </span>
 
-        <!-- Large metric -->
-        <div class="text-4xl md:text-5xl font-display font-bold text-cobalt-500 dark:text-cobalt-300 mb-3">
-          {{ outcome.metric }}
-        </div>
-
-        <!-- Label -->
-        <p class="text-cobalt-600 dark:text-cobalt-200 font-medium text-sm uppercase tracking-wider">
-          {{ outcome.label }}
-        </p>
-
-        <!-- Decorative bottom bar -->
-        <div class="mt-4 flex gap-1" aria-hidden="true">
-          <div
-            v-for="n in 5"
-            :key="n"
-            class="h-0.5 flex-1 transition-colors duration-300"
-            :class="n <= i + 2 ? 'bg-cobalt-500/40 dark:bg-cobalt-300/40' : 'bg-cobalt-500/10 dark:bg-charcoal-200/20'"
-          ></div>
-        </div>
-
-        <!-- Description -->
-        <p v-if="outcome.description" class="text-cobalt-500/70 dark:text-cobalt-300/70 text-sm mt-3">
+      <!-- Label + description -->
+      <div class="flex-1 min-w-0">
+        <span class="text-sm font-medium text-cobalt-600 dark:text-cobalt-200">{{ outcome.label }}</span>
+        <p v-if="outcome.description" class="text-sm text-cobalt-500/60 dark:text-cobalt-300/60 mt-0.5">
           {{ outcome.description }}
         </p>
       </div>

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -21,7 +21,7 @@
             'text-cobalt-500/30 dark:text-cobalt-300/30': !isActive && !isCompleted,
           }"
         >{{ String(index + 1).padStart(2, '0') }}</span>
-        <span class="text-xs font-mono uppercase tracking-wider text-cobalt-500/50 dark:text-cobalt-300/50">{{ phase.label }}</span>
+        <span class="text-xs font-mono tracking-wider text-cobalt-500/50 dark:text-cobalt-300/50">{{ phase.label }}</span>
       </div>
 
       <!-- Content column -->

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -1,231 +1,223 @@
 <template>
-  <div v-if="project && caseStudy" class="bg-cream-100 dark:bg-charcoal min-h-screen">
+  <div class="bg-cream-100 dark:bg-charcoal min-h-screen">
+    <!-- Error state -->
+    <div v-if="!project || !caseStudy" class="flex flex-col items-center justify-center min-h-screen px-6">
+      <span class="text-6xl font-display text-cobalt-500/20 dark:text-cobalt-300/20 mb-4">404</span>
+      <p class="text-lg text-cobalt-500 dark:text-cobalt-300 mb-8">Project not found</p>
+      <router-link
+        to="/"
+        class="font-mono text-sm text-cobalt-500 dark:text-cobalt-300 border border-cobalt-500/20 dark:border-cobalt-300/20 px-4 py-2 hover:bg-cobalt-500/5 dark:hover:bg-cobalt-300/5 transition-colors"
+      >
+        cd ~/
+      </router-link>
+    </div>
 
-    <!-- 1. Hero Image — full-width, top of page -->
-    <section class="pt-24 pb-0 px-6 lg:px-12">
-      <div class="max-w-6xl mx-auto">
-        <img
-          :src="caseStudy.image || `/project-images/${caseStudy.slug}.jpg`"
-          :alt="`${project.title} screenshot`"
-          class="w-full rounded-lg shadow-2xl"
-          loading="eager"
-        />
-      </div>
-    </section>
-
-    <!-- 2. Project Info — title, tags, overview, CTAs -->
-    <section class="py-16 px-6 lg:px-12">
-      <div class="max-w-4xl mx-auto">
-        <!-- Number + Title -->
-        <div class="mb-6">
-          <span class="text-sm font-mono text-cobalt-500/50 dark:text-cobalt-300/50 uppercase tracking-wider block mb-2">
-            / {{ formattedNumber }}
-          </span>
-          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-cobalt-500 dark:text-cobalt-300 leading-tight">
-            {{ project.title }}
-          </h1>
-        </div>
-
-        <!-- Tech Tags -->
-        <div class="flex flex-wrap gap-2 mb-8">
-          <span
-            v-for="tech in project.tech"
-            :key="tech"
-            class="px-3 py-1.5 border border-cobalt-500/20 dark:border-charcoal-200/60 text-xs font-mono text-cobalt-500 dark:text-cobalt-300 lowercase rounded"
-          >
-            {{ tech }}
-          </span>
-        </div>
-
-        <!-- Project Overview — use metaphor description as the main overview -->
-        <p class="text-lg md:text-xl text-cobalt-600 dark:text-cobalt-200 leading-relaxed mb-8 max-w-3xl">
-          {{ caseStudy.metaphor.description }}
-        </p>
-
-        <!-- CTA Buttons -->
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-if="caseStudy.liveUrl"
-            :href="caseStudy.liveUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 px-6 py-3 bg-cobalt-500 text-cream-100 dark:bg-cobalt-400 dark:text-charcoal rounded-lg hover:bg-cobalt-600 dark:hover:bg-cobalt-300 transition-colors duration-200 font-semibold text-sm"
-          >
-            Live Website
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-          </a>
-          <a
-            v-if="project.github"
-            :href="project.github"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 px-6 py-3 border border-cobalt-500/30 dark:border-charcoal-200/60 text-cobalt-500 dark:text-cobalt-300 rounded-lg hover:border-cobalt-500/60 dark:hover:border-cobalt-300/60 transition-colors duration-200 font-semibold text-sm"
-          >
-            View Source
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-          </a>
-        </div>
-
-        <!-- Metadata -->
-        <div class="grid grid-cols-3 gap-6 mt-10 pt-8 border-t border-cobalt-500/10 dark:border-charcoal-200/30">
-          <div>
-            <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 uppercase tracking-wider block mb-1">Duration</span>
-            <span class="text-base font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.duration }}</span>
+    <template v-else>
+      <!-- Header Section -->
+      <section class="pt-32 pb-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-6xl mx-auto">
+          <div class="mb-8">
+            <span class="text-6xl md:text-7xl lg:text-8xl font-display text-cobalt-500 dark:text-cobalt-300 block mb-4">
+              {{ formattedNumber }}
+            </span>
+            <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-cobalt-500 dark:text-cobalt-300 leading-tight">
+              {{ project.title }}
+            </h1>
           </div>
-          <div>
-            <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 uppercase tracking-wider block mb-1">Role</span>
-            <span class="text-base font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.role }}</span>
+
+          <div class="flex flex-wrap gap-3 mb-8">
+            <span
+              v-for="tag in project.tech"
+              :key="tag"
+              class="pill-badge"
+            >
+              {{ tag }}
+            </span>
           </div>
-          <div>
-            <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 uppercase tracking-wider block mb-1">Year</span>
-            <span class="text-base font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.year }}</span>
+
+          <p class="text-xl md:text-2xl font-display text-cobalt-500 dark:text-cobalt-300 max-w-3xl">
+            {{ caseStudy.tagline }}
+          </p>
+        </div>
+      </section>
+
+      <!-- Hero Image -->
+      <section class="border-b border-cobalt-500/20">
+        <div class="max-w-6xl mx-auto px-6 lg:px-12 py-12">
+          <img
+            :src="caseStudy.image || `/project-images/${caseStudy.slug}.jpg`"
+            :alt="`${project.title} screenshot`"
+            class="w-full shadow-2xl"
+            loading="eager"
+            @error="($event.target as HTMLImageElement).style.display = 'none'"
+          />
+        </div>
+      </section>
+
+      <!-- About + Metadata — side by side -->
+      <section class="py-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-3 gap-12">
+          <div class="lg:col-span-2">
+            <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-6">### about</h2>
+            <p class="text-lg md:text-xl text-cobalt-600 dark:text-cobalt-200 leading-relaxed">
+              {{ caseStudy.description || project.description }}
+            </p>
+          </div>
+          <div class="lg:col-span-1">
+            <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-6">### details</h2>
+            <dl class="space-y-4">
+              <div class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2">
+                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Duration</dt>
+                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.duration }}</dd>
+              </div>
+              <div class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2">
+                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Role</dt>
+                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.role }}</dd>
+              </div>
+              <div class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2">
+                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Year</dt>
+                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">{{ caseStudy.year }}</dd>
+              </div>
+              <div v-if="caseStudy.liveUrl" class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2">
+                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Live</dt>
+                <dd>
+                  <a
+                    :href="caseStudy.liveUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-sm font-display text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity inline-flex items-center gap-1"
+                  >
+                    website
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                    </svg>
+                  </a>
+                </dd>
+              </div>
+              <div v-if="project.github" class="flex justify-between pb-2">
+                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Source</dt>
+                <dd>
+                  <a
+                    :href="project.github"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-sm font-display text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity inline-flex items-center gap-1"
+                  >
+                    github
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                    </svg>
+                  </a>
+                </dd>
+              </div>
+            </dl>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <!-- 3. Tech Stack Marquee -->
-    <section class="overflow-hidden border-y border-cobalt-500/20 dark:border-charcoal-200/40 py-4">
-      <Marquee :duration="20" class="py-2">
-        <div class="flex items-center gap-6 px-4">
-          <span
-            v-for="tag in project.tech"
-            :key="tag"
-            class="text-xl md:text-2xl font-display font-bold text-cobalt-500 dark:text-cobalt-300 lowercase whitespace-nowrap"
-          >{{ tag }}</span>
-          <svg viewBox="0 0 40 24" class="w-8 h-5 text-cobalt-500/40 dark:text-cobalt-300/40" aria-hidden="true">
-            <path d="M5 12h20M20 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-          </svg>
+      <!-- Architecture Diagram -->
+      <section class="py-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-4xl mx-auto">
+          <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-8">### architecture</h2>
+          <ArchitectureDiagram :slug="slug" />
         </div>
-      </Marquee>
-    </section>
+      </section>
 
-    <!-- 4. Architecture Diagram -->
-    <section class="py-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-8">### architecture</h2>
-        <ArchitectureDiagram :slug="slug" />
-      </div>
-    </section>
-
-    <!-- 5. Content Sections — Journey, Outcomes, Lessons -->
-    <section class="py-16 px-6 lg:px-12">
-      <div class="max-w-4xl mx-auto space-y-16">
-        <JourneyTimeline
-          :phases="caseStudy.timeline"
-          accent-color="cobalt-500"
-        />
-
-        <div class="flex items-center justify-center gap-4" aria-hidden="true">
-          <div class="h-px flex-1 bg-cobalt-500/15 dark:bg-charcoal-200/30"></div>
-          <svg viewBox="0 0 20 20" class="w-4 h-4 text-cobalt-500/30 dark:text-cobalt-300/30">
-            <polygon points="10,2 12,8 18,8 13,12 15,18 10,14 5,18 7,12 2,8 8,8" fill="currentColor"/>
-          </svg>
-          <div class="h-px flex-1 bg-cobalt-500/15 dark:bg-charcoal-200/30"></div>
+      <!-- Journey Timeline — full bleed bg variation -->
+      <section class="py-16 px-6 lg:px-12 bg-cobalt-500/[0.02] dark:bg-cobalt-300/[0.03]">
+        <div class="max-w-4xl mx-auto">
+          <JourneyTimeline
+            :phases="caseStudy.timeline"
+            accent-color="cobalt-500"
+          />
         </div>
+      </section>
 
-        <OutcomesGrid :outcomes="caseStudy.outcomes" />
-
-        <div class="flex items-center justify-center gap-4" aria-hidden="true">
-          <div class="h-px flex-1 bg-cobalt-500/15 dark:bg-charcoal-200/30"></div>
-          <svg viewBox="0 0 40 20" class="w-6 h-3 text-cobalt-500/30 dark:text-cobalt-300/30">
-            <path d="M0 10 Q10 0, 20 10 Q30 20, 40 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          <div class="h-px flex-1 bg-cobalt-500/15 dark:bg-charcoal-200/30"></div>
+      <!-- Outcomes — compact horizontal strip -->
+      <section class="py-16 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-4xl mx-auto">
+          <OutcomesGrid :outcomes="caseStudy.outcomes" />
         </div>
+      </section>
 
-        <LessonsLearned :lessons="caseStudy.lessonsLearned" />
-      </div>
-    </section>
+      <!-- Navigation — with project titles -->
+      <section class="py-12 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-6xl mx-auto">
+          <div class="flex items-center justify-between">
+            <router-link
+              v-if="prevProject"
+              :to="{ name: 'case-study', params: { slug: prevProject.slug } }"
+              class="group flex items-center gap-4 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
+              :aria-label="`Previous project: ${prevProject.title}`"
+            >
+              <svg viewBox="0 0 24 24" class="w-6 h-6 text-cobalt-500 dark:text-cobalt-300 group-hover:-translate-x-1 transition-transform" aria-hidden="true">
+                <path d="M12 5v14M5 12l7 7 7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+              <div>
+                <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 block">Previous</span>
+                <span class="font-display text-sm">{{ prevProject.title }}</span>
+              </div>
+            </router-link>
+            <div v-else class="w-24"></div>
 
-    <!-- 6. Navigation — Next Project -->
-    <section class="py-16 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
-      <div class="max-w-4xl mx-auto">
-        <div class="flex items-center justify-between">
-          <router-link
-            v-if="prevProject"
-            :to="{ name: 'case-study', params: { slug: prevProject.slug } }"
-            class="group flex items-center gap-3 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity"
-            aria-label="Previous project"
-          >
-            <svg viewBox="0 0 24 24" class="w-5 h-5 rotate-180 group-hover:-translate-x-1 transition-transform" aria-hidden="true">
-              <path d="M5 12h14M12 5l7 7-7 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-            <span class="text-sm font-mono">Previous</span>
-          </router-link>
-          <div v-else></div>
+            <router-link
+              to="/"
+              class="font-mono text-sm text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
+            >
+              cd ~/
+            </router-link>
 
-          <router-link
-            to="/"
-            class="text-sm font-mono text-cobalt-500/50 dark:text-cobalt-300/50 hover:text-cobalt-500 dark:hover:text-cobalt-300 transition-colors"
-          >
-            all projects
-          </router-link>
-
-          <router-link
-            v-if="nextProject"
-            :to="{ name: 'case-study', params: { slug: nextProject.slug } }"
-            class="group flex items-center gap-3 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity"
-            aria-label="Next project"
-          >
-            <span class="text-sm font-mono">Next Project</span>
-            <svg viewBox="0 0 24 24" class="w-5 h-5 group-hover:translate-x-1 transition-transform" aria-hidden="true">
-              <path d="M5 12h14M12 5l7 7-7 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </router-link>
-          <div v-else></div>
+            <router-link
+              v-if="nextProject"
+              :to="{ name: 'case-study', params: { slug: nextProject.slug } }"
+              class="group flex items-center gap-4 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
+              :aria-label="`Next project: ${nextProject.title}`"
+            >
+              <div class="text-right">
+                <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 block">Next</span>
+                <span class="font-display text-sm">{{ nextProject.title }}</span>
+              </div>
+              <svg viewBox="0 0 24 24" class="w-6 h-6 text-cobalt-500 dark:text-cobalt-300 group-hover:translate-x-1 transition-transform" aria-hidden="true">
+                <path d="M12 5v14M5 12l7 7 7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </router-link>
+            <div v-else class="w-24"></div>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <!-- Footer -->
-    <Footer />
+      <!-- Footer -->
+      <Footer />
+    </template>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, watchEffect } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
+import { defineComponent, computed } from 'vue'
 import { getProjectBySlug, getProjectIndex } from '../data/projects'
 import JourneyTimeline from '../components/case-study/JourneyTimeline.vue'
 import OutcomesGrid from '../components/case-study/OutcomesGrid.vue'
-import LessonsLearned from '../components/case-study/LessonsLearned.vue'
 import ArchitectureDiagram from '../components/case-study/ArchitectureDiagram.vue'
 import Footer from '../components/layout/Footer.vue'
-import Marquee from '../components/ui/Marquee.vue'
 
 export default defineComponent({
   name: 'CaseStudy',
   components: {
     JourneyTimeline,
     OutcomesGrid,
-    LessonsLearned,
     ArchitectureDiagram,
     Footer,
-    Marquee,
   },
   props: {
     slug: { type: String, required: true },
   },
   setup(props) {
-    const router = useRouter()
-    const route = useRoute()
     const project = computed(() => getProjectBySlug(props.slug))
     const caseStudy = computed(() => project.value?.caseStudy)
 
     const formattedNumber = computed(() => {
       const index = getProjectIndex(props.slug)
       return (index + 1).toString().padStart(2, '0')
-    })
-
-    watchEffect(() => {
-      if (!project.value || !caseStudy.value) {
-        router.replace({ name: 'home', hash: '#case-studies' })
-      }
     })
 
     const prevProject = computed(() => {

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -140,6 +140,12 @@
         </div>
       </section>
 
+      <section class="py-8 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
+        <div class="max-w-4xl mx-auto">
+          <LessonsLearned :lessons="caseStudy.lessonsLearned" />
+        </div>
+      </section>
+
       <!-- Navigation — with project titles -->
       <section class="py-12 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
         <div class="max-w-6xl mx-auto">
@@ -198,6 +204,7 @@ import { getProjectBySlug, getProjectIndex } from '../data/projects'
 import JourneyTimeline from '../components/case-study/JourneyTimeline.vue'
 import OutcomesGrid from '../components/case-study/OutcomesGrid.vue'
 import ArchitectureDiagram from '../components/case-study/ArchitectureDiagram.vue'
+import LessonsLearned from '../components/case-study/LessonsLearned.vue'
 import Footer from '../components/layout/Footer.vue'
 
 export default defineComponent({
@@ -206,6 +213,7 @@ export default defineComponent({
     JourneyTimeline,
     OutcomesGrid,
     ArchitectureDiagram,
+    LessonsLearned,
     Footer,
   },
   props: {


### PR DESCRIPTION
This updates the case study detail experience with a cleaner editorial layout, terminal-inspired hero styling, a full-bleed journey section, and a compact impact strip.

It also rewrites architecture labels and hero metadata so the content reads more clearly, while removing the old marquee, metaphor banner, lessons block, and decorative dividers.

It adds an explicit 404 state for missing projects, hides missing hero screenshots gracefully, and updates next/previous navigation to show project titles.