### PR TITLE
[codex] portfolio UI polish and QA fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist-ssr
 skills/
 skills-lock.json
 node-compile-cache/
+.gstack/

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -1,14 +1,8 @@
 <template>
   <div
     ref="cardRef"
-    class="group bg-cream-100 border overflow-hidden transition-all duration-500 reveal revealed"
-    :class="{
-      'border-cobalt-500 shadow-lg shadow-cobalt-500/10': isActive,
-      'border-cobalt-500/30': !isActive && !isCompleted,
-      'border-cobalt-500/20': isCompleted && !isActive,
-    }"
-    :style="{ transitionDelay: (index * 100) + 'ms' }"
-    data-cursor="card"
+    class="group reveal revealed"
+    :style="{ transitionDelay: (index * 80) + 'ms' }"
   >
     <!-- Phase entry -->
     <div

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -1,9 +1,14 @@
 <template>
   <div
     ref="cardRef"
-    class="group reveal"
-    :class="{ revealed: isRevealed }"
-    :style="{ transitionDelay: (index * 80) + 'ms' }"
+    class="group bg-cream-100 border overflow-hidden transition-all duration-500 reveal revealed"
+    :class="{
+      'border-cobalt-500 shadow-lg shadow-cobalt-500/10': isActive,
+      'border-cobalt-500/30': !isActive && !isCompleted,
+      'border-cobalt-500/20': isCompleted && !isActive,
+    }"
+    :style="{ transitionDelay: (index * 100) + 'ms' }"
+    data-cursor="card"
   >
     <!-- Phase entry -->
     <div

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     ref="cardRef"
-    class="group reveal revealed"
+    class="group reveal"
+    :class="{ revealed: isRevealed }"
     :style="{ transitionDelay: (index * 80) + 'ms' }"
   >
     <!-- Phase entry -->

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -43,21 +43,42 @@
         </p>
       </div>
 
-      <!-- Decorative Elements -->
-      <div class="relative flex items-center justify-center gap-8 py-12">
-        <!-- Star -->
-        <svg viewBox="0 0 50 50" class="w-16 h-16 text-cobalt-500 animate-pulse-slow" aria-hidden="true">
-          <polygon points="25,2 31,18 48,18 34,28 40,45 25,35 10,45 16,28 2,18 19,18" fill="currentColor"/>
-        </svg>
+      <!-- Profile Panel -->
+      <div class="grid gap-8 md:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] items-start py-12">
+        <div class="border border-cobalt-500/20 p-8 md:p-10">
+          <p class="text-xs uppercase tracking-[0.3em] text-cobalt-500/70 mb-4">Currently</p>
+          <div class="space-y-4 text-cobalt-600">
+            <div>
+              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Base</p>
+              <p class="text-xl font-serif italic text-cobalt-500">Palma de Mallorca</p>
+            </div>
+            <div>
+              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Focus</p>
+              <p class="text-lg leading-relaxed">Vue 3 interfaces, component systems, and frontends that feel calm and considered.</p>
+            </div>
+            <div>
+              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Off-screen</p>
+              <p class="text-lg leading-relaxed">Sailing, open-source, and long walks that usually turn into product ideas.</p>
+            </div>
+          </div>
+        </div>
 
-        <!-- Snake -->
-        <svg viewBox="0 0 80 40" class="w-24 h-12 text-cobalt-500" aria-hidden="true">
-          <path d="M5 20 Q15 5, 25 20 Q35 35, 45 20 Q55 5, 65 20 Q75 35, 75 20" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
-        </svg>
+        <div class="border border-cobalt-500/30 p-8 md:p-10 min-h-[22rem] flex flex-col justify-between">
+          <div>
+            <p class="text-7xl md:text-8xl font-serif italic text-cobalt-500 leading-none">VC</p>
+            <p class="mt-4 text-cobalt-600 leading-relaxed">
+              I like interfaces with strong hierarchy, restrained motion, and enough personality to be remembered.
+            </p>
+          </div>
 
-        <!-- Profile Photo Placeholder -->
-        <div class="w-48 h-64 bg-cobalt-500/10 border border-cobalt-500/30 rounded-lg flex items-center justify-center text-cobalt-500 font-display" role="img" aria-label="Vlad Caraseli profile photo">
-          <span class="text-lg">photo</span>
+          <div class="flex items-center gap-5 pt-10 text-cobalt-500">
+            <svg viewBox="0 0 50 50" class="w-12 h-12">
+              <polygon points="25,2 31,18 48,18 34,28 40,45 25,35 10,45 16,28 2,18 19,18" fill="currentColor"/>
+            </svg>
+            <svg viewBox="0 0 80 40" class="w-16 h-8">
+              <path d="M5 20 Q15 5, 25 20 Q35 35, 45 20 Q55 5, 65 20 Q75 35, 75 20" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -49,7 +49,7 @@
             :alt="`${project.title} screenshot`"
             class="w-full shadow-2xl"
             loading="eager"
-            @error="($event.target as HTMLImageElement).style.display = 'none'"
+            @error="handleImageError"
           />
         </div>
       </section>
@@ -240,12 +240,20 @@ export default defineComponent({
       return p ? { slug: caseStudy.value.nextProject, title: p.title } : null
     })
 
+    const handleImageError = (event: Event) => {
+      const image = event.target
+      if (image instanceof HTMLImageElement) {
+        image.style.display = 'none'
+      }
+    }
+
     return {
       project,
       caseStudy,
       prevProject,
       nextProject,
       formattedNumber,
+      handleImageError,
     }
   },
 })

--- a/src/pages/Contact.vue
+++ b/src/pages/Contact.vue
@@ -2,68 +2,62 @@
   <div class="bg-cream-100 min-h-screen pt-32 flex flex-col">
     <div class="flex-1 max-w-4xl mx-auto px-6 lg:px-12 pb-24 flex flex-col justify-center">
       <!-- Animated Headlines -->
-      <div class="mb-16">
+      <div class="mb-12 md:mb-16 max-w-2xl">
         <p class="text-xl md:text-2xl text-cobalt-600 mb-6">
           Reach out to create something
         </p>
-        <div class="space-y-3">
+        <div class="space-y-2 md:space-y-3">
           <p
             v-for="(word, index) in words"
             :key="index"
             class="text-3xl md:text-5xl lg:text-6xl font-display text-cobalt-500 transition-all duration-500"
             :class="{
               'opacity-100': currentWordIndex === index,
-              'opacity-30': currentWordIndex !== index
+              'opacity-40': currentWordIndex !== index
             }"
           >
             {{ word }}<span v-if="hasPeriod(index)">.</span>
           </p>
         </div>
+        <p class="mt-8 text-lg md:text-xl text-cobalt-600 leading-relaxed">
+          Best first touch is LinkedIn. Send a short note with the project, the role, and the timeline. That gets the fastest response.
+        </p>
       </div>
 
-      <!-- Contact Links -->
-      <div class="flex flex-col sm:flex-row items-center justify-center gap-12 mb-16">
-        <!-- Email Sunburst -->
-        <a
-          href="mailto:vlad@example.com"
-          class="group relative w-32 h-32 md:w-36 md:h-36 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-4 rounded-full"
-          aria-label="Send email"
-        >
-          <svg viewBox="0 0 100 100" class="w-full h-full text-cobalt-500 group-hover:rotate-45 transition-transform duration-700" aria-hidden="true">
-            <!-- Sunburst rays -->
-            <g v-for="n in 16" :key="n" :transform="`rotate(${n * 22.5} 50 50)`">
-              <line x1="50" y1="5" x2="50" y2="20" stroke="currentColor" stroke-width="1.5"/>
-            </g>
-            <circle cx="50" cy="50" r="18" fill="none" stroke="currentColor" stroke-width="1.5"/>
-          </svg>
-          <span class="absolute inset-0 flex items-center justify-center font-display text-cobalt-500 text-base md:text-lg">
-            email
-          </span>
-        </a>
-
-        <!-- LinkedIn Sunburst -->
-        <a
+      <!-- Primary Actions -->
+      <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-14">
+        <a 
           href="https://www.linkedin.com/in/caraseli/"
           target="_blank"
           rel="noopener noreferrer"
-          class="group relative w-32 h-32 md:w-36 md:h-36 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-4 rounded-full"
-          aria-label="LinkedIn profile"
+          class="inline-flex items-center justify-center px-7 py-3 bg-cobalt-500 text-cream-100 font-medium hover:opacity-85 transition-opacity"
         >
-          <svg viewBox="0 0 100 100" class="w-full h-full text-cobalt-500 group-hover:rotate-45 transition-transform duration-700" aria-hidden="true">
-            <!-- Sunburst rays -->
-            <g v-for="n in 16" :key="n" :transform="`rotate(${n * 22.5} 50 50)`">
-              <line x1="50" y1="5" x2="50" y2="20" stroke="currentColor" stroke-width="1.5"/>
-            </g>
-            <circle cx="50" cy="50" r="18" fill="none" stroke="currentColor" stroke-width="1.5"/>
-          </svg>
-          <span class="absolute inset-0 flex items-center justify-center font-display text-cobalt-500 text-base md:text-lg">
-            linkedin
-          </span>
+          Start on LinkedIn
+        </a>
+
+        <a 
+          href="https://github.com/caraseli02?tab=repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center px-7 py-3 border border-cobalt-500 text-cobalt-500 font-medium hover:bg-cobalt-500 hover:text-cream-100 transition-colors"
+        >
+          Browse GitHub
         </a>
       </div>
 
-      <!-- Playful Text -->
-      <p class="text-center text-cobalt-500 text-xl lowercase font-display">
+      <!-- Supporting Notes -->
+      <div class="grid gap-4 md:grid-cols-2 text-cobalt-600 mb-12 md:mb-16">
+        <div class="border border-cobalt-500/20 p-5">
+          <p class="text-xs uppercase tracking-[0.25em] text-cobalt-500/60 mb-2">Good fit</p>
+          <p class="leading-relaxed">Frontend builds, design system work, UI polish, and product-facing Vue projects.</p>
+        </div>
+        <div class="border border-cobalt-500/20 p-5">
+          <p class="text-xs uppercase tracking-[0.25em] text-cobalt-500/60 mb-2">Helpful in the first message</p>
+          <p class="leading-relaxed">What you are building, what stage it is in, and where the interface currently feels weak.</p>
+        </div>
+      </div>
+
+      <p class="text-cobalt-500 text-xl lowercase font-serif italic">
         don't be shy
       </p>
     </div>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="bg-cream-100 min-h-screen">
     <!-- Hero Section -->
-    <section class="pt-32 pb-16 px-6 lg:px-12 min-h-screen flex flex-col justify-center">
+    <section class="pt-24 md:pt-32 pb-10 md:pb-16 px-6 lg:px-12 min-h-[78svh] md:min-h-screen flex flex-col justify-center">
       <div class="max-w-5xl mx-auto text-center">
         <!-- Main Hero Text -->
-        <div class="mb-6">
-          <p class="text-2xl md:text-3xl text-cobalt-500 mb-4 font-normal">
+        <div class="mb-5 md:mb-6">
+          <p class="text-xl md:text-3xl text-cobalt-500 mb-3 md:mb-4 font-normal">
             Hi my name is
           </p>
-          <h1 class="font-display text-5xl md:text-7xl lg:text-8xl text-cobalt-500 tracking-tight leading-none">
+          <h1 class="font-serif italic text-5xl sm:text-6xl md:text-7xl lg:text-8xl xl:text-9xl text-cobalt-500 tracking-tight leading-none">
             Vlad Caraseli
           </h1>
         </div>
 
         <!-- Role Descriptor with 3D Text Rotator -->
-        <div class="flex items-center justify-center gap-3 text-cobalt-500 text-xl md:text-2xl mt-8">
+        <div class="flex items-center justify-center gap-2 md:gap-3 text-cobalt-500 text-lg sm:text-xl md:text-2xl mt-6 md:mt-8">
           <span>I'm a</span>
           <TextRotator 
             :words="['Webapps', 'UI/UX', 'Components']"
@@ -24,8 +24,8 @@
         </div>
 
         <!-- Circular Case Studies Stamp -->
-        <div class="mt-16 flex justify-center">
-          <a href="#case-studies" class="group relative w-28 h-28">
+        <div class="mt-12 md:mt-16 flex justify-center">
+          <a href="#case-studies" class="group relative w-24 h-24 md:w-28 md:h-28">
             <svg viewBox="0 0 100 100" class="w-full h-full text-cobalt-500 animate-spin-slow" aria-hidden="true">
               <defs>
                 <path id="circle" d="M 50,50 m -37,0 a 37,37 0 1,1 74,0 a 37,37 0 1,1 -74,0"/>
@@ -44,11 +44,8 @@
         </div>
       </div>
     </section>
-
-
-
     <!-- Case Studies Section -->
-    <section id="case-studies" class="py-16 px-6 lg:px-12">
+    <section id="case-studies" class="py-10 md:py-16 px-6 lg:px-12">
       <div class="max-w-6xl mx-auto">
         <h2 class="text-lg font-display text-cobalt-500 lowercase mb-8 px-4">
           case studies


### PR DESCRIPTION
## Summary

This pull request packages the recent UI polish and QA work that was previously sitting as local commits on `master` into a reviewable branch. The user-facing issue was that several portfolio surfaces still felt unfinished or fragile: the case study marquee was too heavy on mobile, the journey timeline cards could read like blank whitespace on first pass, the about and contact pages had unfinished or low-clarity presentation, and the homepage emitted console noise from broken image requests.

The root cause was a mix of visual pacing problems and leftover implementation artifacts. Several layouts were tuned more for desktop than small screens, one about-page placeholder signaled incomplete content, the contact page emphasized atmosphere over a decisive call to action, and the homepage still referenced image assets that no longer existed.

The fix tightens the case-study presentation, makes the timeline cards render with clearer visual affordance, improves the About and Contact pages so they read as finished product rather than placeholders, reduces excess mobile spacing on the homepage, and removes the broken homepage image requests that were generating console errors. Local QA artifacts are also ignored so browser and audit output do not dirty the working tree during future review runs.

## Validation

I validated the changes with `npm run build` and browser-based checks on the homepage, about page, contact page, and case study flows. No `docs/project-status.md` or `docs/plans/*` update was needed because this branch only packages already-completed UI polish and QA fixes rather than changing tracked roadmap sequencing.
