### PR TITLE
feat: improve portfolio positioning and editorial polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,54 @@
-# Vue 3 + Typescript + Vite
+# Vlad Caraseli Portfolio
 
-This template should help get you started developing with Vue 3 and Typescript in Vite.
+Personal portfolio built with Vue 3, TypeScript, Vite, and Tailwind CSS v4.
 
-## Recommended IDE Setup
+Live goals for this site:
 
-[VSCode](https://code.visualstudio.com/) + [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur). Make sure to enable `vetur.experimental.templateInterpolationService` in settings!
+- make hiring managers understand the value fast
+- show real product/frontend range through case studies
+- keep the visual language editorial, high-contrast, and memorable
 
-### If Using `<script setup>`
+## Stack
 
-[`<script setup>`](https://github.com/vuejs/rfcs/pull/227) is a feature that is currently in RFC stage. To get proper IDE support for the syntax, use [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) instead of Vetur (and disable Vetur).
+- Vue 3
+- TypeScript
+- Vite
+- Tailwind CSS v4
+- Vue Router
 
-## Type Support For `.vue` Imports in TS
+## Main sections
 
-Since TypeScript cannot handle type information for `.vue` imports, they are shimmed to be a generic Vue component type by default. In most cases this is fine if you don't really care about component prop types outside of templates. However, if you wish to get actual prop types in `.vue` imports (for example to get props validation when using manual `h(...)` calls), you can use the following:
+- Home: positioning, proof, and featured case studies
+- About: working style, specialties, and background
+- Contact: fast path for LinkedIn/GitHub outreach
+- Case studies: deep dives into selected projects
 
-### If Using Volar
+## Local development
 
-Run `Volar: Switch TS Plugin on/off` from VSCode command palette.
+```bash
+pnpm install
+pnpm dev
+```
 
-### If Using Vetur
+## Production build
 
-1. Install and add `@vuedx/typescript-plugin-vue` to the [plugins section](https://www.typescriptlang.org/tsconfig#plugins) in `tsconfig.json`
-2. Delete `src/shims-vue.d.ts` as it is no longer needed to provide module info to Typescript
-3. Open `src/main.ts` in VSCode
-4. Open the VSCode command palette
-5. Search and run "Select TypeScript version" -> "Use workspace version"
+```bash
+pnpm build
+pnpm preview
+```
+
+## Design direction
+
+This iteration leans into an editorial portfolio aesthetic:
+
+- Bodoni Moda for high-impact display moments
+- Familjen Grotesk for cleaner body copy
+- cream paper background + cobalt accents
+- stronger proof-first homepage structure
+- more scannable about/contact pages
+
+## Notes
+
+- Route metadata is updated per page for stronger SEO/share text.
+- `/projects` redirects to the homepage case studies section.
+- External links use `rel="noopener noreferrer"`.

--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Vlad Caraseli - Vue.js Web Developer based in Palma de Mallorca. Building modern web applications with Vue 3, Nuxt, TypeScript, and Tailwind CSS."
+      content="Vlad Caraseli is a frontend engineer building polished product interfaces, design systems, and high-trust web experiences with Vue, React, TypeScript, and Nuxt."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,700;6..96,800&family=Familjen+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Vlad Caraseli | Vue.js Developer</title>
+    <title>Vlad Caraseli | Frontend Engineer for Product Teams</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -1,34 +1,31 @@
-/* ./src/index.css */
-@import url("https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,700;6..96,800&family=Familjen+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
 
 @import "tailwindcss";
 
-/* Class-based dark mode */
 @variant dark (&:where(.dark, .dark *));
 
-/* Theme configuration (replaces tailwind.config.js) */
 @theme {
-  --font-sans: "Manrope", system-ui, -apple-system, sans-serif;
-  --font-display: "Azeret Mono", "JetBrains Mono", monospace;
-  --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --font-sans: "Familjen Grotesk", system-ui, -apple-system, sans-serif;
+  --font-display: "Bodoni Moda", Georgia, serif;
+  --font-mono: "IBM Plex Mono", monospace;
 
-  --color-cream-50: #faf9f6;
-  --color-cream-100: #f5f5dc;
-  --color-cream-200: #f0ead6;
-  --color-cream-300: #e8e0d0;
+  --color-cream-50: #fcfaf4;
+  --color-cream-100: #f5f0e6;
+  --color-cream-200: #ece2d1;
+  --color-cream-300: #dfd1bc;
 
-  --color-cobalt-100: #b3b3ff;
-  --color-cobalt-200: #8080ff;
-  --color-cobalt-300: #4d4dff;
-  --color-cobalt-400: #3333ff;
-  --color-cobalt-500: #0000ff;
-  --color-cobalt-600: #0000cc;
-  --color-cobalt-700: #000099;
+  --color-cobalt-100: #ccd1ff;
+  --color-cobalt-200: #99a1ff;
+  --color-cobalt-300: #6975ff;
+  --color-cobalt-400: #3d4cff;
+  --color-cobalt-500: #1f32ff;
+  --color-cobalt-600: #1724c9;
+  --color-cobalt-700: #111b8f;
 
-  --color-charcoal: #0d1117;
-  --color-charcoal-50: #161b22;
-  --color-charcoal-100: #21262d;
-  --color-charcoal-200: #30363d;
+  --color-charcoal: #0e1220;
+  --color-charcoal-50: #141a2a;
+  --color-charcoal-100: #1b2134;
+  --color-charcoal-200: #2a3248;
 
   --animate-fade-in: fadeIn 0.6s ease-out forwards;
   --animate-slide-up: slideUp 0.6s ease-out forwards;
@@ -41,39 +38,60 @@
 
 @layer base {
   :root {
-    --color-bg: oklch(0.96 0.01 90);
-    --color-bg-subtle: oklch(0.93 0.012 90);
-    --color-surface: oklch(0.98 0.008 90);
-    --color-primary: oklch(0.45 0.2 265);
-    --color-primary-hover: oklch(0.38 0.22 265);
-    --color-primary-light: oklch(0.92 0.06 265);
-    --color-text: oklch(0.28 0.02 265);
-    --color-text-muted: oklch(0.45 0.03 265);
-    --color-text-subtle: oklch(0.65 0.03 265);
-    --color-border: oklch(0.85 0.02 265);
-    --color-border-light: oklch(0.92 0.015 265);
-    --color-selection: oklch(0.45 0.2 265);
+    --color-bg: oklch(0.965 0.012 85);
+    --color-bg-subtle: oklch(0.94 0.015 85);
+    --color-surface: oklch(0.985 0.01 85);
+    --color-primary: oklch(0.44 0.23 270);
+    --color-primary-hover: oklch(0.37 0.24 270);
+    --color-primary-light: oklch(0.91 0.055 270);
+    --color-text: oklch(0.23 0.03 275);
+    --color-text-muted: oklch(0.42 0.04 275);
+    --color-text-subtle: oklch(0.58 0.03 275);
+    --color-border: oklch(0.83 0.03 270);
+    --color-border-light: oklch(0.9 0.02 270);
+    --color-selection: oklch(0.44 0.23 270);
   }
 
   .dark {
-    --color-bg: oklch(0.14 0.015 265);
-    --color-bg-subtle: oklch(0.18 0.018 265);
-    --color-surface: oklch(0.16 0.015 265);
-    --color-primary: oklch(0.65 0.2 265);
-    --color-primary-hover: oklch(0.72 0.22 265);
-    --color-primary-light: oklch(0.25 0.06 265);
-    --color-text: oklch(0.9 0.02 265);
-    --color-text-muted: oklch(0.7 0.03 265);
-    --color-text-subtle: oklch(0.5 0.03 265);
-    --color-border: oklch(0.3 0.02 265);
-    --color-border-light: oklch(0.22 0.015 265);
-    --color-selection: oklch(0.55 0.2 265);
+    --color-bg: oklch(0.14 0.02 270);
+    --color-bg-subtle: oklch(0.18 0.02 270);
+    --color-surface: oklch(0.17 0.018 270);
+    --color-primary: oklch(0.67 0.2 270);
+    --color-primary-hover: oklch(0.74 0.22 270);
+    --color-primary-light: oklch(0.26 0.06 270);
+    --color-text: oklch(0.92 0.02 270);
+    --color-text-muted: oklch(0.72 0.03 270);
+    --color-text-subtle: oklch(0.55 0.03 270);
+    --color-border: oklch(0.31 0.02 270);
+    --color-border-light: oklch(0.22 0.015 270);
+    --color-selection: oklch(0.58 0.2 270);
   }
 
   html {
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    font-family:
+      "Familjen Grotesk",
+      system-ui,
+      -apple-system,
+      sans-serif;
+    background:
+      radial-gradient(circle at top left, rgba(31, 50, 255, 0.08), transparent 28%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent 22%), var(--color-bg);
+    color: var(--color-text);
+    transition:
+      background-color 0.3s ease,
+      color 0.3s ease;
+  }
+
+  .dark body {
+    background:
+      radial-gradient(circle at top left, rgba(105, 117, 255, 0.14), transparent 30%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 18%), var(--color-bg);
   }
 
   h1,
@@ -85,17 +103,8 @@
     text-wrap: balance;
   }
 
-  body {
-    font-family:
-      "Manrope",
-      system-ui,
-      -apple-system,
-      sans-serif;
-    background-color: var(--color-bg);
-    color: var(--color-text);
-    transition:
-      background-color 0.3s ease,
-      color 0.3s ease;
+  p {
+    text-wrap: pretty;
   }
 
   ::selection {
@@ -111,7 +120,7 @@
 
 @layer components {
   .pill-badge {
-    @apply px-4 py-1.5 border border-cobalt-500 dark:border-cobalt-300 rounded-full text-sm text-cobalt-500 dark:text-cobalt-300 lowercase transition-all duration-300;
+    @apply px-4 py-1.5 border border-cobalt-500/30 dark:border-cobalt-300/30 rounded-full text-sm text-cobalt-600 dark:text-cobalt-200 lowercase transition-all duration-300 bg-white/60 dark:bg-charcoal-50/70;
   }
 
   .pill-badge:hover {
@@ -127,11 +136,27 @@
   }
 
   .section-subheading {
-    @apply text-lg text-cobalt-600 max-w-2xl;
+    @apply text-lg text-cobalt-600 dark:text-cobalt-100/80 max-w-2xl;
   }
 
   .glass {
-    @apply bg-white/80 backdrop-blur-lg;
+    @apply bg-white/70 dark:bg-charcoal-50/70 backdrop-blur-lg;
+  }
+
+  .panel-surface {
+    @apply border border-cobalt-500/15 dark:border-cobalt-300/15 bg-white/72 dark:bg-charcoal-50/72 backdrop-blur-md shadow-[0_20px_60px_rgba(31,50,255,0.08)];
+  }
+
+  .ink-link {
+    @apply inline-flex items-center gap-2 text-sm font-medium uppercase tracking-[0.2em] text-cobalt-500 dark:text-cobalt-300 transition-colors hover:text-cobalt-700 dark:hover:text-white;
+  }
+
+  .editorial-kicker {
+    @apply text-[11px] font-mono uppercase tracking-[0.32em] text-cobalt-500/75 dark:text-cobalt-300/70;
+  }
+
+  .editorial-rule {
+    @apply h-px w-full bg-cobalt-500/15 dark:bg-cobalt-300/15;
   }
 
   .reveal {
@@ -141,6 +166,7 @@
       opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
       transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
   }
+
   .reveal.revealed {
     opacity: 1;
     transform: translateY(0);
@@ -159,15 +185,33 @@
   .animation-delay-200 {
     animation-delay: 200ms;
   }
+
   .animation-delay-400 {
     animation-delay: 400ms;
   }
+
   .animation-delay-600 {
     animation-delay: 600ms;
   }
+
+  .paper-grid {
+    background-image:
+      linear-gradient(to right, rgba(31, 50, 255, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(31, 50, 255, 0.08) 1px, transparent 1px);
+    background-size: 34px 34px;
+  }
+
+  .dark .paper-grid {
+    background-image:
+      linear-gradient(to right, rgba(153, 161, 255, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(153, 161, 255, 0.08) 1px, transparent 1px);
+  }
+
+  .text-stroke-soft {
+    -webkit-text-stroke: 1px rgba(31, 50, 255, 0.2);
+  }
 }
 
-/* Keyframes */
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/components/case-study/CaseStudyListItem.vue
+++ b/src/components/case-study/CaseStudyListItem.vue
@@ -1,49 +1,71 @@
 <template>
-  <div class="border border-cobalt-500 mb-4 hover:bg-cobalt-500/5 transition-colors">
+  <article
+    class="group panel-surface relative overflow-hidden before:absolute before:inset-y-0 before:left-0 before:w-1 before:bg-cobalt-500 before:opacity-0 before:transition-opacity hover:before:opacity-100"
+  >
     <router-link
       :to="{ name: 'case-study', params: { slug } }"
-      class="group flex items-center py-6 px-4 md:px-6 gap-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-2"
+      class="grid gap-6 px-5 py-6 md:grid-cols-[auto_minmax(0,1.3fr)_minmax(0,0.9fr)] md:px-7 md:py-8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-2"
     >
-      <!-- Number -->
-      <span
-        class="text-3xl md:text-4xl lg:text-5xl font-display text-cobalt-500 w-12 md:w-16 shrink-0 tabular-nums"
-      >
-        {{ formattedNumber }}
-      </span>
-
-      <!-- Title + Description -->
-      <div class="flex-1 min-w-0 px-2">
-        <h3 class="text-lg md:text-xl lg:text-2xl font-bold text-cobalt-500">
-          {{ title }}
-        </h3>
-        <p v-if="description" class="hidden md:block text-sm text-cobalt-500/60 mt-1">
-          {{ description }}
-        </p>
-      </div>
-
-      <!-- Tags -->
-      <div class="hidden md:flex items-center gap-2 shrink-0">
-        <span v-for="tag in tags" :key="tag" class="pill-badge">
-          {{ tag }}
+      <div class="flex items-start gap-4 md:block md:pr-3">
+        <span
+          class="block text-4xl md:text-5xl lg:text-6xl font-display text-cobalt-500 leading-none tabular-nums"
+        >
+          {{ formattedNumber }}
         </span>
+        <span class="editorial-kicker mt-2 block">selected case study</span>
       </div>
 
-      <!-- Image -->
+      <div class="min-w-0 space-y-4">
+        <div>
+          <h3 class="text-2xl md:text-3xl font-semibold text-cobalt-500 dark:text-cobalt-200">
+            {{ title }}
+          </h3>
+          <p class="mt-3 max-w-2xl text-base md:text-lg text-cobalt-600 dark:text-cobalt-100/75">
+            {{ description }}
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <span v-for="tag in tags" :key="tag" class="pill-badge">
+            {{ tag }}
+          </span>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-5 pt-2">
+          <span class="ink-link">
+            open case study
+            <span aria-hidden="true">↗</span>
+          </span>
+
+          <a
+            v-if="github"
+            :href="github"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ink-link"
+            @click.stop
+          >
+            source
+            <span aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </div>
+
       <div
         v-if="image"
-        class="hidden lg:block shrink-0 w-40 h-24 rounded overflow-hidden border border-cobalt-500/20"
+        class="overflow-hidden rounded-[1.5rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] md:min-h-[14rem]"
       >
         <img
           :src="image"
-          :alt="title"
+          :alt="`${title} preview`"
           loading="lazy"
-          width="160"
-          height="96"
-          class="w-full h-full object-cover"
+          width="640"
+          height="440"
+          class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
         />
       </div>
     </router-link>
-  </div>
+  </article>
 </template>
 
 <script setup lang="ts">
@@ -57,15 +79,15 @@ const props = withDefaults(
     tags?: string[];
     image?: string;
     description?: string;
+    github?: string;
   }>(),
   {
     tags: () => [],
     image: "",
     description: "",
+    github: "",
   },
 );
 
-const formattedNumber = computed(() => {
-  return props.number.toString().padStart(2, "0");
-});
+const formattedNumber = computed(() => props.number.toString().padStart(2, "0"));
 </script>

--- a/src/components/case-study/CaseStudyListItem.vue
+++ b/src/components/case-study/CaseStudyListItem.vue
@@ -53,7 +53,7 @@
 
       <div
         v-if="image"
-        class="overflow-hidden rounded-[1.5rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] md:min-h-[14rem]"
+        class="overflow-hidden rounded-[1.5rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] md:self-start"
       >
         <img
           :src="image"
@@ -61,7 +61,7 @@
           loading="lazy"
           width="640"
           height="440"
-          class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+          class="aspect-[16/10] h-auto max-h-[18rem] w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.04] md:max-h-[16rem]"
         />
       </div>
     </router-link>

--- a/src/components/case-study/JourneyTimeline.vue
+++ b/src/components/case-study/JourneyTimeline.vue
@@ -1,8 +1,10 @@
 <template>
   <section class="py-12">
     <div class="mb-10">
-      <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-2">### journey</h2>
-      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">How this project unfolded</p>
+      <p class="editorial-kicker mb-3">project journey</p>
+      <h2 class="text-3xl font-display text-charcoal dark:text-cobalt-100 md:text-4xl">
+        How the build unfolded from problem to payoff
+      </h2>
     </div>
 
     <div ref="containerRef" class="space-y-0">

--- a/src/components/case-study/LessonsLearned.vue
+++ b/src/components/case-study/LessonsLearned.vue
@@ -1,11 +1,12 @@
 <template>
   <section class="py-12">
     <div class="mb-12">
-      <h2 class="text-3xl md:text-4xl font-display text-cobalt-500 dark:text-cobalt-300 mb-4">
-        Key Takeaways
+      <p class="editorial-kicker mb-3">takeaways</p>
+      <h2 class="mb-4 text-3xl font-display text-charcoal dark:text-cobalt-100 md:text-4xl">
+        What this project sharpened
       </h2>
-      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">
-        What I learned building this project
+      <p class="text-lg text-charcoal-200 dark:text-cobalt-100/72">
+        Actionable lessons pulled from the build, not filler reflection.
       </p>
     </div>
 

--- a/src/components/case-study/OutcomesGrid.vue
+++ b/src/components/case-study/OutcomesGrid.vue
@@ -1,8 +1,10 @@
 <template>
   <section>
     <div class="mb-10">
-      <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-2">### impact</h2>
-      <p class="text-lg text-cobalt-600 dark:text-cobalt-200">Measurable results</p>
+      <p class="editorial-kicker mb-3">measurable impact</p>
+      <h2 class="text-3xl font-display text-charcoal dark:text-cobalt-100 md:text-4xl">
+        The proof points that matter on a fast scan
+      </h2>
     </div>
 
     <!-- Horizontal metrics strip -->

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -7,13 +7,14 @@
   >
     <!-- Phase entry -->
     <div
-      class="py-6 px-4 md:px-0 md:flex md:items-start md:gap-6 transition-colors duration-200"
+      class="rounded-[1.5rem] border border-cobalt-500/12 bg-white/72 px-4 py-5 transition-colors duration-200 dark:border-cobalt-300/12 dark:bg-charcoal-50/72 md:px-5"
       :class="{
-        'bg-cobalt-500/[0.03] dark:bg-cobalt-300/[0.05]': isActive,
+        'shadow-[0_18px_40px_rgba(31,50,255,0.08)] ring-1 ring-cobalt-500/12 dark:ring-cobalt-300/12':
+          isActive,
       }"
     >
       <!-- Index + label column -->
-      <div class="flex items-baseline gap-3 mb-2 md:mb-0 md:w-40 shrink-0">
+      <div class="mb-3 flex items-baseline gap-3 md:mb-0 md:w-40 md:shrink-0">
         <span
           class="text-sm font-mono tabular-nums"
           :class="{
@@ -28,10 +29,8 @@
       </div>
 
       <!-- Content column -->
-      <div
-        class="flex-1 md:border-t md:border-cobalt-500/10 dark:md:border-charcoal-200/30 md:pt-6 md:pb-2"
-      >
-        <h3 class="text-lg md:text-xl font-bold text-cobalt-500 dark:text-cobalt-300 mb-2">
+      <div class="flex-1 md:border-l md:border-cobalt-500/10 md:pl-6 dark:md:border-cobalt-300/12">
+        <h3 class="mb-2 text-xl font-semibold text-charcoal dark:text-cobalt-100 md:text-2xl">
           {{ phase.title }}
         </h3>
         <p class="text-cobalt-600 dark:text-cobalt-200 leading-relaxed text-sm md:text-base mb-3">

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -1,26 +1,55 @@
 <template>
   <footer
-    class="py-8 px-6 border-t border-cobalt-500/10 bg-cream-100 dark:bg-charcoal dark:border-cobalt-300/10"
+    class="border-t border-cobalt-500/10 bg-cream-100/70 px-6 py-8 dark:bg-charcoal dark:border-cobalt-300/10"
   >
-    <div class="max-w-6xl mx-auto flex items-center justify-between text-sm text-cobalt-500/60">
-      <span class="font-mono lowercase">vlad caraseli &copy; {{ year }}</span>
-      <div class="flex items-center gap-6">
-        <a
-          href="https://github.com/caraseli02"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center min-h-[44px] hover:text-cobalt-500 transition-colors"
-          >github</a
+    <div class="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+      <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+        <p class="editorial-kicker mb-3">currently open to</p>
+        <h2 class="max-w-xl text-3xl md:text-4xl font-display text-cobalt-500 dark:text-cobalt-200">
+          Product-facing frontend work, design systems, and UI polish that ships clean.
+        </h2>
+        <div
+          class="mt-6 flex flex-wrap items-center gap-4 text-sm text-cobalt-600 dark:text-cobalt-100/70"
         >
-        <a
-          href="https://linkedin.com/in/vlad-caraseli"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center min-h-[44px] hover:text-cobalt-500 transition-colors"
-          >linkedin</a
-        >
+          <span>Based in Palma de Mallorca</span>
+          <span aria-hidden="true">•</span>
+          <span>Vue, React, Nuxt, TypeScript</span>
+        </div>
       </div>
-      <span class="font-display">palma de mallorca</span>
+
+      <div class="flex flex-col justify-between gap-5 border border-cobalt-500/15 p-6 md:p-8">
+        <div>
+          <p class="editorial-kicker mb-4">find me fast</p>
+          <div class="space-y-3">
+            <a
+              href="https://github.com/caraseli02"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ink-link"
+            >
+              GitHub ↗
+            </a>
+            <a
+              href="https://linkedin.com/in/vlad-caraseli"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ink-link"
+            >
+              LinkedIn ↗
+            </a>
+            <router-link to="/contact" class="ink-link">Contact page →</router-link>
+          </div>
+        </div>
+
+        <div class="editorial-rule"></div>
+
+        <div
+          class="flex items-center justify-between gap-4 text-sm text-cobalt-500/65 dark:text-cobalt-300/65"
+        >
+          <span class="font-mono lowercase">vlad caraseli © {{ year }}</span>
+          <span class="uppercase tracking-[0.2em]">palma de mallorca</span>
+        </div>
+      </div>
     </div>
   </footer>
 </template>

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -3,17 +3,24 @@
     class="border-t border-cobalt-500/10 bg-cream-100/70 px-6 py-8 dark:bg-charcoal dark:border-cobalt-300/10"
   >
     <div class="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-      <div class="panel-surface rounded-[2rem] p-6 md:p-8">
-        <p class="editorial-kicker mb-3">currently open to</p>
-        <h2 class="max-w-xl text-3xl md:text-4xl font-display text-cobalt-500 dark:text-cobalt-200">
-          Product-facing frontend work, design systems, and UI polish that ships clean.
-        </h2>
-        <div
-          class="mt-6 flex flex-wrap items-center gap-4 text-sm text-cobalt-600 dark:text-cobalt-100/70"
-        >
-          <span>Based in Palma de Mallorca</span>
-          <span aria-hidden="true">•</span>
-          <span>Vue, React, Nuxt, TypeScript</span>
+      <div
+        class="relative overflow-hidden rounded-[2rem] border border-cobalt-500/20 bg-cobalt-700 p-6 text-cream-50 shadow-[0_28px_80px_rgba(17,27,143,0.22)] md:p-8 dark:border-cobalt-300/20 dark:bg-cobalt-700"
+      >
+        <div class="absolute inset-0 opacity-[0.08]" aria-hidden="true">
+          <div class="paper-grid h-full w-full"></div>
+        </div>
+        <div class="relative">
+          <p class="mb-3 text-[11px] font-mono uppercase tracking-[0.32em] text-cobalt-100/70">
+            currently open to
+          </p>
+          <h2 class="max-w-xl text-3xl font-display text-white md:text-4xl">
+            Product-facing frontend work, design systems, and UI polish that ships clean.
+          </h2>
+          <div class="mt-6 flex flex-wrap items-center gap-4 text-sm text-cobalt-100/78">
+            <span>Based in Palma de Mallorca</span>
+            <span aria-hidden="true">•</span>
+            <span>Vue, React, Nuxt, TypeScript</span>
+          </div>
         </div>
       </div>
 

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -5,12 +5,12 @@
         <div>
           <p class="editorial-kicker mb-4">about vlad caraseli</p>
           <h1
-            class="max-w-5xl text-[3.3rem] leading-[0.95] font-display text-cobalt-500 dark:text-cobalt-200 sm:text-[4.2rem] md:text-[5.6rem]"
+            class="max-w-5xl text-[3.3rem] leading-[0.95] font-display text-charcoal dark:text-cobalt-100 sm:text-[4.2rem] md:text-[5.6rem]"
           >
             I like product interfaces with strong hierarchy, useful tension, and zero fake polish.
           </h1>
           <p
-            class="mt-6 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78 md:text-xl"
+            class="mt-6 max-w-2xl text-lg leading-relaxed text-charcoal-200 dark:text-cobalt-100/78 md:text-xl"
           >
             Born in Moldova, now based in Palma de Mallorca. I build frontend systems that stay calm
             under complexity — commerce flows, dashboard interfaces, component libraries, and the UI

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -1,105 +1,146 @@
 <template>
-  <div class="bg-cream-100 dark:bg-charcoal min-h-screen pt-32">
-    <div class="max-w-4xl mx-auto px-6 lg:px-12 pb-24">
-      <!-- Hero -->
-      <div class="mb-16">
-        <h1
-          class="text-4xl md:text-6xl lg:text-7xl font-display text-cobalt-500 leading-tight mb-4"
-        >
-          I'm Vlad Caraseli,
-        </h1>
-        <h2 class="text-4xl md:text-6xl lg:text-7xl font-display text-cobalt-500 leading-tight">
-          it's nice to meet you
-        </h2>
-      </div>
+  <div class="min-h-screen bg-cream-100 pt-28 dark:bg-charcoal md:pt-32">
+    <div class="mx-auto max-w-7xl px-6 pb-20 md:px-10 lg:px-12">
+      <section class="grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_22rem] lg:items-start">
+        <div>
+          <p class="editorial-kicker mb-4">about vlad caraseli</p>
+          <h1
+            class="max-w-5xl text-[3.3rem] leading-[0.95] font-display text-cobalt-500 dark:text-cobalt-200 sm:text-[4.2rem] md:text-[5.6rem]"
+          >
+            I like product interfaces with strong hierarchy, useful tension, and zero fake polish.
+          </h1>
+          <p
+            class="mt-6 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78 md:text-xl"
+          >
+            Born in Moldova, now based in Palma de Mallorca. I build frontend systems that stay calm
+            under complexity — commerce flows, dashboard interfaces, component libraries, and the UI
+            layers teams actually rely on.
+          </p>
+        </div>
 
-      <!-- Bio Content -->
-      <div class="space-y-6 text-lg md:text-xl text-cobalt-600 leading-relaxed mb-16">
-        <p>
-          I was born in Moldova and have spent the last decade crafting digital experiences across
-          Europe. Currently, I'm based in the beautiful Mediterranean city of Palma de Mallorca,
-          where I combine work with a passion for sailing and sunshine.
-        </p>
-
-        <p>
-          My journey into web development started with a curiosity for how things work on the
-          internet. That curiosity led me to specialize in Vue.js and the modern JavaScript
-          ecosystem, where I've spent 6+ years building everything from interactive dashboards to
-          complex e-commerce platforms.
-        </p>
-
-        <p>
-          I've worked with startups, agencies, and enterprise clients, helping them bring their
-          visions to life through clean code and thoughtful user interfaces. My approach combines
-          technical precision with creative problem-solving.
-        </p>
-
-        <p>
-          When I'm not coding, you'll find me exploring Mallorca's coastline, contributing to
-          open-source projects, or diving deep into the latest frontend frameworks. I believe in
-          building software that's not just functional, but delightful to use.
-        </p>
-
-        <p class="font-display text-cobalt-500">Let's create something amazing together.</p>
-      </div>
-
-      <!-- Profile Panel -->
-      <div class="grid gap-8 md:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] items-start py-12">
-        <div class="border border-cobalt-500/20 p-8 md:p-10">
-          <p class="text-xs uppercase tracking-[0.3em] text-cobalt-500/70 mb-4">Currently</p>
-          <div class="space-y-4 text-cobalt-600">
+        <aside class="panel-surface rounded-[2rem] p-6 md:p-8">
+          <p class="editorial-kicker mb-4">snapshot</p>
+          <div class="space-y-5 text-cobalt-600 dark:text-cobalt-100/75">
             <div>
-              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Base</p>
-              <p class="text-xl font-serif italic text-cobalt-500">Palma de Mallorca</p>
-            </div>
-            <div>
-              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Focus</p>
-              <p class="text-lg leading-relaxed">
-                Vue 3 interfaces, component systems, and frontends that feel calm and considered.
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                base
+              </p>
+              <p class="mt-1 text-2xl font-display text-cobalt-500 dark:text-cobalt-200">
+                Palma de Mallorca
               </p>
             </div>
+            <div class="editorial-rule"></div>
             <div>
-              <p class="text-sm uppercase tracking-[0.25em] text-cobalt-500/60 mb-1">Off-screen</p>
-              <p class="text-lg leading-relaxed">
-                Sailing, open-source, and long walks that usually turn into product ideas.
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                specialty
+              </p>
+              <p class="mt-1">
+                Frontend architecture, UX clarity, design systems, and product-facing
+                implementation.
+              </p>
+            </div>
+            <div class="editorial-rule"></div>
+            <div>
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                off-screen
+              </p>
+              <p class="mt-1">
+                Sailing, long walks, open-source rabbit holes, and interface references I probably
+                should not be collecting.
               </p>
             </div>
           </div>
-        </div>
+        </aside>
+      </section>
 
-        <div
-          class="border border-cobalt-500/30 p-8 md:p-10 min-h-[22rem] flex flex-col justify-between"
-        >
-          <div>
-            <p class="text-7xl md:text-8xl font-serif italic text-cobalt-500 leading-none">VC</p>
-            <p class="mt-4 text-cobalt-600 leading-relaxed">
-              I like interfaces with strong hierarchy, restrained motion, and enough personality to
-              be remembered.
+      <section class="mt-14 grid gap-5 md:grid-cols-3">
+        <article class="panel-surface p-6">
+          <p class="editorial-kicker mb-3">01 — what I do best</p>
+          <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78">
+            Turn vague product needs into sharp, production-ready interfaces with real hierarchy and
+            better decision-making built into the layout.
+          </p>
+        </article>
+        <article class="panel-surface p-6">
+          <p class="editorial-kicker mb-3">02 — how I work</p>
+          <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78">
+            Design-minded engineering: thoughtful systems, clean implementation, and enough visual
+            restraint that the important moments hit harder.
+          </p>
+        </article>
+        <article class="panel-surface p-6">
+          <p class="editorial-kicker mb-3">03 — where I add leverage</p>
+          <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78">
+            Complex frontends, refactors that improve trust, and design-system work that keeps teams
+            shipping without turning every screen into a one-off.
+          </p>
+        </article>
+      </section>
+
+      <section class="mt-16 grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-start">
+        <div>
+          <p class="editorial-kicker mb-4">working style</p>
+          <h2 class="text-3xl font-display text-cobalt-500 dark:text-cobalt-200 md:text-4xl">
+            I care about interfaces that earn trust fast.
+          </h2>
+          <div
+            class="mt-6 space-y-5 text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78"
+          >
+            <p>
+              That usually means fewer gimmicks, stronger copy hierarchy, and components that feel
+              like they belong to the same product universe.
+            </p>
+            <p>
+              I enjoy the work between “looks good” and “actually holds up” — accessibility,
+              resilience, edge states, motion restraint, and making dense product logic feel
+              legible.
             </p>
           </div>
+        </div>
 
-          <div class="flex items-center gap-5 pt-10 text-cobalt-500">
-            <svg viewBox="0 0 50 50" class="w-12 h-12">
-              <polygon
-                points="25,2 31,18 48,18 34,28 40,45 25,35 10,45 16,28 2,18 19,18"
-                fill="currentColor"
-              />
-            </svg>
-            <svg viewBox="0 0 80 40" class="w-16 h-8">
-              <path
-                d="M5 20 Q15 5, 25 20 Q35 35, 45 20 Q55 5, 65 20 Q75 35, 75 20"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="3"
-                stroke-linecap="round"
-              />
-            </svg>
+        <div class="border border-cobalt-500/15 p-6 md:p-8">
+          <p class="editorial-kicker mb-5">good fit projects</p>
+          <div class="space-y-4 text-cobalt-600 dark:text-cobalt-100/78">
+            <div>
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                product UI
+              </p>
+              <p class="mt-1 text-lg">Dashboards, commerce flows, account areas, internal tools.</p>
+            </div>
+            <div>
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                systems
+              </p>
+              <p class="mt-1 text-lg">
+                Component libraries, design systems, typed frontend architecture.
+              </p>
+            </div>
+            <div>
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                polish
+              </p>
+              <p class="mt-1 text-lg">
+                UX cleanup, visual hierarchy, interaction refinement, and handoff-ready frontend
+                implementation.
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
 
-    <!-- Footer -->
     <Footer />
   </div>
 </template>

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -51,13 +51,17 @@
       <!-- Hero Image -->
       <section class="border-b border-cobalt-500/20">
         <div class="max-w-6xl mx-auto px-6 lg:px-12 py-12">
-          <img
-            :src="caseStudy.image || `/project-images/${caseStudy.slug}.jpg`"
-            :alt="`${project.title} screenshot`"
-            class="w-full shadow-2xl"
-            loading="eager"
-            @error="handleImageError"
-          />
+          <div
+            class="overflow-hidden rounded-[2rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] shadow-2xl"
+          >
+            <img
+              :src="caseStudy.image || `/project-images/${caseStudy.slug}.jpg`"
+              :alt="`${project.title} screenshot`"
+              class="h-auto max-h-[70vh] w-full object-cover object-top"
+              loading="eager"
+              @error="handleImageError"
+            />
+          </div>
         </div>
       </section>
 

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -1,58 +1,153 @@
 <template>
-  <div class="bg-cream-100 dark:bg-charcoal min-h-screen">
-    <!-- Error state -->
+  <div class="min-h-screen bg-cream-100 dark:bg-charcoal">
     <div
       v-if="!project || !caseStudy"
-      class="flex flex-col items-center justify-center min-h-screen px-6"
+      class="flex min-h-screen flex-col items-center justify-center px-6"
     >
-      <span class="text-6xl font-display text-cobalt-500/20 dark:text-cobalt-300/20 mb-4">404</span>
-      <p class="text-lg text-cobalt-500 dark:text-cobalt-300 mb-8">Project not found</p>
+      <span class="mb-4 text-6xl font-display text-cobalt-500/20 dark:text-cobalt-300/20">404</span>
+      <p class="mb-8 text-lg text-cobalt-700 dark:text-cobalt-100">Project not found</p>
       <router-link
         to="/"
-        class="font-mono text-sm text-cobalt-500 dark:text-cobalt-300 border border-cobalt-500/20 dark:border-cobalt-300/20 px-4 py-2 hover:bg-cobalt-500/5 dark:hover:bg-cobalt-300/5 transition-colors"
+        class="border border-cobalt-500/20 px-4 py-2 font-mono text-sm text-cobalt-700 transition-colors hover:bg-cobalt-500/5 dark:border-cobalt-300/20 dark:text-cobalt-100 dark:hover:bg-cobalt-300/5"
       >
         cd ~/
       </router-link>
     </div>
 
     <template v-else>
-      <!-- Header Section -->
       <section
-        class="pt-32 pb-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40"
+        class="relative overflow-hidden px-6 pb-12 pt-28 md:px-10 md:pb-16 md:pt-36 lg:px-12"
       >
-        <div class="max-w-6xl mx-auto">
-          <div class="mb-8">
-            <span
-              class="text-6xl md:text-7xl lg:text-8xl font-display text-cobalt-500 dark:text-cobalt-300 block mb-4"
-            >
-              {{ formattedNumber }}
-            </span>
-            <h1
-              class="text-4xl md:text-5xl lg:text-6xl font-bold text-cobalt-500 dark:text-cobalt-300 leading-tight"
-            >
-              {{ project.title }}
-            </h1>
-          </div>
+        <div class="paper-grid absolute inset-x-4 inset-y-8 rounded-[2rem] opacity-50"></div>
 
-          <div class="flex flex-wrap gap-3 mb-8">
-            <span v-for="tag in project.tech" :key="tag" class="pill-badge">
-              {{ tag }}
-            </span>
-          </div>
+        <div class="relative mx-auto max-w-7xl">
+          <div class="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_22rem] lg:items-stretch">
+            <div
+              class="relative overflow-hidden rounded-[2rem] border border-cobalt-500/18 bg-cobalt-700 p-6 text-white shadow-[0_30px_90px_rgba(17,27,143,0.22)] md:p-8 lg:p-10"
+            >
+              <div class="absolute inset-0 opacity-[0.08]" aria-hidden="true">
+                <div class="paper-grid h-full w-full"></div>
+              </div>
 
-          <p
-            class="text-xl md:text-2xl font-display text-cobalt-500 dark:text-cobalt-300 max-w-3xl"
-          >
-            {{ caseStudy.tagline }}
-          </p>
+              <div class="relative">
+                <p
+                  class="mb-4 text-[11px] font-mono uppercase tracking-[0.32em] text-cobalt-100/70"
+                >
+                  {{ formattedNumber }} • {{ project.category }}
+                </p>
+
+                <h1
+                  class="max-w-4xl text-[3.2rem] leading-[0.92] font-display text-white sm:text-[4.2rem] md:text-[5.2rem] lg:text-[6rem]"
+                >
+                  {{ project.title }}
+                </h1>
+
+                <p class="mt-5 max-w-3xl text-xl leading-relaxed text-cobalt-100/82 md:text-2xl">
+                  {{ caseStudy.tagline }}
+                </p>
+
+                <p class="mt-6 max-w-3xl text-base leading-relaxed text-cobalt-100/72 md:text-lg">
+                  {{ caseStudy.description || project.description }}
+                </p>
+
+                <div class="mt-8 flex flex-wrap gap-2.5">
+                  <span
+                    v-for="tag in project.tech"
+                    :key="tag"
+                    class="border border-white/12 bg-white/7 px-3 py-1.5 text-xs font-mono uppercase tracking-[0.16em] text-cobalt-100/82"
+                  >
+                    {{ tag }}
+                  </span>
+                </div>
+
+                <div class="mt-8 flex flex-wrap items-center gap-4">
+                  <a
+                    v-if="caseStudy.liveUrl"
+                    :href="caseStudy.liveUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center justify-center bg-white px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-700 transition-opacity hover:opacity-85"
+                  >
+                    View live ↗
+                  </a>
+                  <a
+                    v-if="project.github"
+                    :href="project.github"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center justify-center border border-white/18 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-colors hover:bg-white hover:text-cobalt-700"
+                  >
+                    View source ↗
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            <aside class="panel-surface flex flex-col justify-between rounded-[2rem] p-6 md:p-8">
+              <div>
+                <p class="editorial-kicker mb-5">project facts</p>
+                <dl class="space-y-4">
+                  <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
+                    <dt
+                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-300/70"
+                    >
+                      duration
+                    </dt>
+                    <dd class="mt-1 text-2xl font-display text-charcoal dark:text-cobalt-100">
+                      {{ caseStudy.duration }}
+                    </dd>
+                  </div>
+                  <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
+                    <dt
+                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-300/70"
+                    >
+                      role
+                    </dt>
+                    <dd class="mt-1 text-lg text-charcoal-200 dark:text-cobalt-100/82">
+                      {{ caseStudy.role }}
+                    </dd>
+                  </div>
+                  <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
+                    <dt
+                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-300/70"
+                    >
+                      year
+                    </dt>
+                    <dd class="mt-1 text-lg text-charcoal-200 dark:text-cobalt-100/82">
+                      {{ caseStudy.year }}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div class="mt-8">
+                <p class="editorial-kicker mb-4">top outcomes</p>
+                <div class="space-y-3">
+                  <div
+                    v-for="outcome in heroOutcomes"
+                    :key="outcome.label"
+                    class="rounded-[1.5rem] border border-cobalt-500/12 bg-white/75 p-4 dark:border-cobalt-300/12 dark:bg-charcoal-50/75"
+                  >
+                    <p class="text-3xl font-display text-charcoal dark:text-cobalt-100">
+                      {{ outcome.metric }}
+                    </p>
+                    <p
+                      class="mt-1 text-sm leading-relaxed text-charcoal-200 dark:text-cobalt-100/72"
+                    >
+                      {{ outcome.label }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </aside>
+          </div>
         </div>
       </section>
 
-      <!-- Hero Image -->
-      <section class="border-b border-cobalt-500/20">
-        <div class="max-w-6xl mx-auto px-6 lg:px-12 py-12">
+      <section class="px-6 pb-14 md:px-10 lg:px-12">
+        <div class="mx-auto max-w-7xl">
           <div
-            class="overflow-hidden rounded-[2rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] shadow-2xl"
+            class="overflow-hidden rounded-[2rem] border border-cobalt-500/15 bg-white/75 shadow-[0_24px_70px_rgba(31,50,255,0.08)] dark:border-cobalt-300/15 dark:bg-charcoal-50/75"
           >
             <img
               :src="caseStudy.image || `/project-images/${caseStudy.slug}.jpg`"
@@ -65,215 +160,130 @@
         </div>
       </section>
 
-      <!-- About + Metadata — side by side -->
-      <section
-        class="py-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40"
-      >
-        <div class="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-3 gap-12">
-          <div class="lg:col-span-2">
-            <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-6">### about</h2>
-            <p class="text-lg md:text-xl text-cobalt-600 dark:text-cobalt-200 leading-relaxed">
+      <section class="px-6 pb-16 md:px-10 lg:px-12">
+        <div class="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+            <p class="editorial-kicker mb-4">why this project matters</p>
+            <h2
+              class="max-w-3xl text-3xl font-display text-charcoal dark:text-cobalt-100 md:text-4xl"
+            >
+              Built to show product judgment, not just implementation range.
+            </h2>
+            <p
+              class="mt-5 max-w-2xl text-lg leading-relaxed text-charcoal-200 dark:text-cobalt-100/78"
+            >
               {{ caseStudy.description || project.description }}
             </p>
+            <p
+              class="mt-5 max-w-2xl text-base leading-relaxed text-cobalt-700 dark:text-cobalt-100/68"
+            >
+              The goal was not just to make something work. It was to make complex logic feel
+              legible, credible, and fast to trust on first scan.
+            </p>
           </div>
-          <div class="lg:col-span-1">
-            <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-6">### details</h2>
-            <dl class="space-y-4">
-              <div
-                class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2"
-              >
-                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">
-                  Duration
-                </dt>
-                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">
-                  {{ caseStudy.duration }}
-                </dd>
-              </div>
-              <div
-                class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2"
-              >
-                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Role</dt>
-                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">
-                  {{ caseStudy.role }}
-                </dd>
-              </div>
-              <div
-                class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2"
-              >
-                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Year</dt>
-                <dd class="text-sm font-display text-cobalt-500 dark:text-cobalt-300">
-                  {{ caseStudy.year }}
-                </dd>
-              </div>
-              <div
-                v-if="caseStudy.liveUrl"
-                class="flex justify-between border-b border-cobalt-500/10 dark:border-charcoal-200/20 pb-2"
-              >
-                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Live</dt>
-                <dd>
-                  <a
-                    :href="caseStudy.liveUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-sm font-display text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity inline-flex items-center gap-1"
-                  >
-                    website
-                    <svg
-                      class="w-3 h-3"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                      ></path>
-                    </svg>
-                  </a>
-                </dd>
-              </div>
-              <div v-if="project.github" class="flex justify-between pb-2">
-                <dt class="text-sm font-mono text-cobalt-500/60 dark:text-cobalt-300/60">Source</dt>
-                <dd>
-                  <a
-                    :href="project.github"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-sm font-display text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 transition-opacity inline-flex items-center gap-1"
-                  >
-                    github
-                    <svg
-                      class="w-3 h-3"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                      ></path>
-                    </svg>
-                  </a>
-                </dd>
-              </div>
-            </dl>
+
+          <div class="grid gap-4 sm:grid-cols-2">
+            <article
+              v-for="(highlight, index) in projectHighlights"
+              :key="highlight"
+              class="panel-surface rounded-[1.6rem] p-5"
+            >
+              <p class="editorial-kicker mb-3">0{{ index + 1 }} — what shipped</p>
+              <p class="text-base leading-relaxed text-charcoal-200 dark:text-cobalt-100/78">
+                {{ highlight }}
+              </p>
+            </article>
           </div>
         </div>
       </section>
 
-      <!-- Architecture Diagram -->
-      <section
-        class="py-16 px-6 lg:px-12 border-b border-cobalt-500/20 dark:border-charcoal-200/40"
-      >
-        <div class="max-w-4xl mx-auto">
-          <h2 class="text-sm font-mono text-cobalt-500 dark:text-cobalt-300 mb-8">
-            ### architecture
-          </h2>
+      <section class="px-6 pb-16 md:px-10 lg:px-12">
+        <div class="mx-auto max-w-7xl panel-surface rounded-[2rem] p-6 md:p-8">
+          <p class="editorial-kicker mb-6">system view</p>
           <ArchitectureDiagram :slug="slug" />
         </div>
       </section>
 
-      <!-- Journey Timeline — full bleed bg variation -->
-      <section class="py-16 px-6 lg:px-12 bg-cobalt-500/[0.02] dark:bg-cobalt-300/[0.03]">
-        <div class="max-w-4xl mx-auto">
-          <JourneyTimeline :phases="caseStudy.timeline" accent-color="cobalt-500" />
+      <section class="px-6 pb-16 md:px-10 lg:px-12">
+        <div
+          class="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1.1fr)_22rem] lg:items-start"
+        >
+          <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+            <JourneyTimeline :phases="caseStudy.timeline" accent-color="cobalt-500" />
+          </div>
+
+          <aside
+            v-if="caseStudy.metaphor"
+            class="relative overflow-hidden rounded-[2rem] border border-cobalt-500/18 bg-cobalt-700 p-6 text-white shadow-[0_24px_70px_rgba(17,27,143,0.2)] md:p-8"
+          >
+            <div class="absolute inset-0 opacity-[0.08]" aria-hidden="true">
+              <div class="paper-grid h-full w-full"></div>
+            </div>
+            <div class="relative">
+              <p class="mb-4 text-[11px] font-mono uppercase tracking-[0.32em] text-cobalt-100/70">
+                core idea
+              </p>
+              <p class="text-3xl font-display text-white md:text-4xl">
+                {{ caseStudy.metaphor.phrase }}
+              </p>
+              <p class="mt-5 text-base leading-relaxed text-cobalt-100/78">
+                {{ caseStudy.metaphor.description }}
+              </p>
+            </div>
+          </aside>
         </div>
       </section>
 
-      <!-- Outcomes — compact horizontal strip -->
-      <section
-        class="py-16 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40"
-      >
-        <div class="max-w-4xl mx-auto">
-          <OutcomesGrid :outcomes="caseStudy.outcomes" />
-        </div>
-      </section>
-
-      <section class="py-8 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40">
-        <div class="max-w-4xl mx-auto">
-          <LessonsLearned :lessons="caseStudy.lessonsLearned" />
-        </div>
-      </section>
-
-      <!-- Navigation — with project titles -->
-      <section
-        class="py-12 px-6 lg:px-12 border-t border-cobalt-500/20 dark:border-charcoal-200/40"
-      >
-        <div class="max-w-6xl mx-auto">
-          <div class="flex items-center justify-between">
-            <router-link
-              v-if="prevProject"
-              :to="{ name: 'case-study', params: { slug: prevProject.slug } }"
-              class="group flex items-center gap-4 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
-              :aria-label="`Previous project: ${prevProject.title}`"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                class="w-6 h-6 text-cobalt-500 dark:text-cobalt-300 group-hover:-translate-x-1 transition-transform"
-                aria-hidden="true"
-              >
-                <path
-                  d="M12 5v14M5 12l7 7 7-7"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-              <div>
-                <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 block"
-                  >Previous</span
-                >
-                <span class="font-display text-sm">{{ prevProject.title }}</span>
-              </div>
-            </router-link>
-            <div v-else class="w-24"></div>
-
-            <router-link
-              to="/"
-              class="font-mono text-sm text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
-            >
-              cd ~/
-            </router-link>
-
-            <router-link
-              v-if="nextProject"
-              :to="{ name: 'case-study', params: { slug: nextProject.slug } }"
-              class="group flex items-center gap-4 text-cobalt-500 dark:text-cobalt-300 hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm transition-opacity"
-              :aria-label="`Next project: ${nextProject.title}`"
-            >
-              <div class="text-right">
-                <span class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 block"
-                  >Next</span
-                >
-                <span class="font-display text-sm">{{ nextProject.title }}</span>
-              </div>
-              <svg
-                viewBox="0 0 24 24"
-                class="w-6 h-6 text-cobalt-500 dark:text-cobalt-300 group-hover:translate-x-1 transition-transform"
-                aria-hidden="true"
-              >
-                <path
-                  d="M12 5v14M5 12l7 7 7-7"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </router-link>
-            <div v-else class="w-24"></div>
+      <section class="px-6 pb-16 md:px-10 lg:px-12">
+        <div class="mx-auto grid max-w-7xl gap-6 lg:grid-cols-2">
+          <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+            <OutcomesGrid :outcomes="caseStudy.outcomes" />
+          </div>
+          <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+            <LessonsLearned :lessons="caseStudy.lessonsLearned" />
           </div>
         </div>
       </section>
 
-      <!-- Footer -->
+      <section class="px-6 pb-16 md:px-10 lg:px-12">
+        <div class="mx-auto grid max-w-7xl gap-4 md:grid-cols-3">
+          <router-link
+            v-if="prevProject"
+            :to="{ name: 'case-study', params: { slug: prevProject.slug } }"
+            class="panel-surface group rounded-[1.5rem] p-5 transition-transform hover:-translate-y-1"
+          >
+            <p class="editorial-kicker mb-3">previous project</p>
+            <p
+              class="text-2xl font-display text-charcoal transition-colors group-hover:text-cobalt-700 dark:text-cobalt-100 dark:group-hover:text-white"
+            >
+              {{ prevProject.title }}
+            </p>
+          </router-link>
+          <div v-else class="hidden md:block"></div>
+
+          <router-link
+            to="/"
+            class="panel-surface flex items-center justify-center rounded-[1.5rem] p-5 text-center text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-700 transition-transform hover:-translate-y-1 dark:text-cobalt-100"
+          >
+            Back to work
+          </router-link>
+
+          <router-link
+            v-if="nextProject"
+            :to="{ name: 'case-study', params: { slug: nextProject.slug } }"
+            class="panel-surface group rounded-[1.5rem] p-5 text-right transition-transform hover:-translate-y-1"
+          >
+            <p class="editorial-kicker mb-3">next project</p>
+            <p
+              class="text-2xl font-display text-charcoal transition-colors group-hover:text-cobalt-700 dark:text-cobalt-100 dark:group-hover:text-white"
+            >
+              {{ nextProject.title }}
+            </p>
+          </router-link>
+          <div v-else class="hidden md:block"></div>
+        </div>
+      </section>
+
       <Footer />
     </template>
   </div>
@@ -299,6 +309,9 @@ const formattedNumber = computed(() => {
   const index = getProjectIndex(props.slug);
   return (index + 1).toString().padStart(2, "0");
 });
+
+const heroOutcomes = computed(() => caseStudy.value?.outcomes.slice(0, 3) ?? []);
+const projectHighlights = computed(() => project.value?.highlights.slice(0, 4) ?? []);
 
 const prevProject = computed(() => {
   if (!caseStudy.value?.prevProject) return null;

--- a/src/pages/Contact.vue
+++ b/src/pages/Contact.vue
@@ -1,101 +1,118 @@
 <template>
-  <div class="bg-cream-100 dark:bg-charcoal min-h-screen pt-32 flex flex-col">
-    <div class="flex-1 max-w-4xl mx-auto px-6 lg:px-12 pb-24 flex flex-col justify-center">
-      <!-- Animated Headlines -->
-      <div class="mb-12 md:mb-16 max-w-2xl">
-        <p class="text-xl md:text-2xl text-cobalt-600 mb-6">Reach out to create something</p>
-        <div class="space-y-2 md:space-y-3">
-          <p
-            v-for="(word, index) in words"
-            :key="index"
-            class="text-3xl md:text-5xl lg:text-6xl font-display text-cobalt-500 transition-all duration-500"
-            :class="{
-              'opacity-100': currentWordIndex === index,
-              'opacity-40': currentWordIndex !== index,
-            }"
+  <div class="min-h-screen bg-cream-100 dark:bg-charcoal pt-28 md:pt-32">
+    <div
+      class="mx-auto grid max-w-7xl gap-10 px-6 pb-20 md:px-10 lg:grid-cols-[minmax(0,1.1fr)_24rem] lg:px-12"
+    >
+      <section>
+        <p class="editorial-kicker mb-4">contact</p>
+        <h1
+          class="max-w-4xl text-[3.2rem] leading-[0.94] font-display text-cobalt-500 dark:text-cobalt-200 sm:text-[4.2rem] md:text-[5.4rem]"
+        >
+          Bring me in when the interface needs to feel
+          <span class="italic">sharper</span>, <span class="italic">clearer</span>, and harder to
+          forget.
+        </h1>
+
+        <div class="mt-8 flex flex-wrap gap-3">
+          <span
+            v-for="word in words"
+            :key="word"
+            class="pill-badge"
+            :class="
+              currentWord === word
+                ? '!bg-cobalt-500 !text-white dark:!bg-cobalt-300 dark:!text-charcoal'
+                : ''
+            "
           >
-            {{ word }}<span v-if="hasPeriod(index)">.</span>
-          </p>
+            {{ word }}
+          </span>
         </div>
-        <p class="mt-8 text-lg md:text-xl text-cobalt-600 leading-relaxed">
-          Best first touch is LinkedIn. Send a short note with the project, the role, and the
-          timeline. That gets the fastest response.
+
+        <p
+          class="mt-8 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78 md:text-xl"
+        >
+          Best first touch is LinkedIn. Send the project, the role, the timeline, and where the
+          product currently feels weak. I can tell pretty quickly where the leverage is.
         </p>
-      </div>
 
-      <!-- Primary Actions -->
-      <div class="flex flex-col sm:flex-row items-start sm:items-center gap-4 mb-14">
-        <a
-          href="https://www.linkedin.com/in/caraseli/"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center justify-center px-7 py-3 bg-cobalt-500 text-cream-100 font-medium hover:opacity-85 transition-opacity"
-        >
-          Start on LinkedIn
-        </a>
-
-        <a
-          href="https://github.com/caraseli02?tab=repositories"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center justify-center px-7 py-3 border border-cobalt-500 text-cobalt-500 font-medium hover:bg-cobalt-500 hover:text-cream-100 transition-colors"
-        >
-          Browse GitHub
-        </a>
-      </div>
-
-      <!-- Supporting Notes -->
-      <div class="grid gap-4 md:grid-cols-2 text-cobalt-600 mb-12 md:mb-16">
-        <div class="border border-cobalt-500/20 p-5">
-          <p class="text-xs uppercase tracking-[0.25em] text-cobalt-500/60 mb-2">Good fit</p>
-          <p class="leading-relaxed">
-            Frontend builds, design system work, UI polish, and product-facing Vue projects.
-          </p>
+        <div class="mt-10 flex flex-wrap items-center gap-4">
+          <a
+            href="https://www.linkedin.com/in/caraseli/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"
+          >
+            Start on LinkedIn ↗
+          </a>
+          <a
+            href="https://github.com/caraseli02?tab=repositories"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center border border-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+          >
+            Browse GitHub ↗
+          </a>
         </div>
-        <div class="border border-cobalt-500/20 p-5">
-          <p class="text-xs uppercase tracking-[0.25em] text-cobalt-500/60 mb-2">
-            Helpful in the first message
-          </p>
-          <p class="leading-relaxed">
-            What you are building, what stage it is in, and where the interface currently feels
-            weak.
-          </p>
-        </div>
-      </div>
+      </section>
 
-      <p class="text-cobalt-500 text-xl lowercase font-serif italic">don't be shy</p>
+      <aside class="panel-surface rounded-[2rem] p-6 md:p-8">
+        <p class="editorial-kicker mb-4">good first message</p>
+        <div class="space-y-5 text-cobalt-600 dark:text-cobalt-100/78">
+          <div>
+            <p
+              class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+            >
+              tell me
+            </p>
+            <p class="mt-1">
+              What you are building, who it is for, and what is not clicking in the current UX.
+            </p>
+          </div>
+          <div class="editorial-rule"></div>
+          <div>
+            <p
+              class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+            >
+              best fit
+            </p>
+            <p class="mt-1">
+              Frontend builds, product UI cleanup, design systems, complex component work, and
+              thoughtful refactors.
+            </p>
+          </div>
+          <div class="editorial-rule"></div>
+          <div>
+            <p
+              class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-300/70"
+            >
+              location
+            </p>
+            <p class="mt-1 text-xl font-display text-cobalt-500 dark:text-cobalt-200">
+              Palma de Mallorca
+            </p>
+          </div>
+        </div>
+      </aside>
     </div>
 
-    <!-- Arch SVG at bottom -->
-    <div class="flex justify-center pb-8">
-      <svg viewBox="0 0 60 80" class="w-20 h-24 text-cobalt-500">
-        <path
-          d="M10 70 Q10 10, 30 10 Q50 10, 50 70"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="3"
-          stroke-linecap="round"
-        />
-      </svg>
-    </div>
+    <Footer />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
+import Footer from "../components/layout/Footer.vue";
 
-const words = ["daring", "playful", "immersive", "enticing", "joyful", "intuitive", "exciting"];
-const currentWordIndex = ref(0);
+const words = ["decisive", "editorial", "usable", "faster", "clearer", "credible", "memorable"];
+const currentWord = ref(words[0]);
 let interval: ReturnType<typeof setInterval> | null = null;
-
-const hasPeriod = (index: number): boolean => {
-  return index === 0 || index === 1 || index === 5;
-};
+let currentIndex = 0;
 
 const startInterval = () => {
   interval = window.setInterval(() => {
-    currentWordIndex.value = (currentWordIndex.value + 1) % words.length;
-  }, 2000);
+    currentIndex = (currentIndex + 1) % words.length;
+    currentWord.value = words[currentIndex];
+  }, 1600);
 };
 
 const stopInterval = () => {
@@ -108,7 +125,7 @@ const stopInterval = () => {
 const handleVisibilityChange = () => {
   if (document.hidden) {
     stopInterval();
-  } else {
+  } else if (!interval) {
     startInterval();
   }
 };

--- a/src/pages/Contact.vue
+++ b/src/pages/Contact.vue
@@ -6,7 +6,7 @@
       <section>
         <p class="editorial-kicker mb-4">contact</p>
         <h1
-          class="max-w-4xl text-[3.2rem] leading-[0.94] font-display text-cobalt-500 dark:text-cobalt-200 sm:text-[4.2rem] md:text-[5.4rem]"
+          class="max-w-4xl text-[3.2rem] leading-[0.94] font-display text-charcoal dark:text-cobalt-100 sm:text-[4.2rem] md:text-[5.4rem]"
         >
           Bring me in when the interface needs to feel
           <span class="italic">sharper</span>, <span class="italic">clearer</span>, and harder to
@@ -29,7 +29,7 @@
         </div>
 
         <p
-          class="mt-8 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78 md:text-xl"
+          class="mt-8 max-w-2xl text-lg leading-relaxed text-charcoal-200 dark:text-cobalt-100/78 md:text-xl"
         >
           Best first touch is LinkedIn. Send the project, the role, the timeline, and where the
           product currently feels weak. I can tell pretty quickly where the leverage is.

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,126 +1,174 @@
 <template>
-  <div class="bg-cream-100 min-h-screen">
-    <!-- Hero Section -->
-    <section
-      class="pt-24 md:pt-32 pb-10 md:pb-16 px-6 lg:px-12 min-h-[78svh] md:min-h-screen flex flex-col justify-center"
-    >
-      <div class="max-w-5xl mx-auto text-center">
-        <!-- Main Hero Text -->
-        <div class="mb-5 md:mb-6">
-          <p class="text-xl md:text-3xl text-cobalt-500 mb-3 md:mb-4 font-normal">Hi my name is</p>
+  <div class="min-h-screen bg-cream-100 dark:bg-charcoal">
+    <section class="relative overflow-hidden px-6 pb-12 pt-28 md:px-10 md:pb-16 md:pt-36 lg:px-12">
+      <div class="paper-grid absolute inset-x-4 inset-y-8 rounded-[2rem] opacity-60"></div>
+      <div
+        class="relative mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,1.2fr)_22rem] lg:items-end"
+      >
+        <div>
+          <p class="editorial-kicker mb-5">
+            frontend engineer • product interfaces • design systems
+          </p>
           <h1
-            class="font-serif italic text-5xl sm:text-6xl md:text-7xl lg:text-8xl xl:text-9xl text-cobalt-500 tracking-tight leading-none"
+            class="max-w-5xl text-[3.6rem] leading-[0.92] font-display text-cobalt-500 dark:text-cobalt-200 sm:text-[4.6rem] md:text-[6rem] lg:text-[7.3rem]"
           >
-            Vlad Caraseli
+            I build interfaces that feel
+            <span class="italic text-stroke-soft text-transparent">decisive</span>
+            before they feel decorative.
           </h1>
-        </div>
+          <p
+            class="mt-6 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/78 md:text-xl"
+          >
+            Vlad Caraseli — frontend engineer for product teams that need sharper UX, cleaner
+            systems, and case-study-worthy execution across Vue, React, Nuxt, and TypeScript.
+          </p>
 
-        <!-- Role Descriptor with 3D Text Rotator -->
-        <div
-          class="flex items-center justify-center gap-2 md:gap-3 text-cobalt-500 text-lg sm:text-xl md:text-2xl mt-6 md:mt-8"
-        >
-          <span>I'm a</span>
-          <TextRotator :words="['Webapps', 'UI/UX', 'Components']" :interval="2500" />
-          <span>developer</span>
-        </div>
-
-        <!-- Circular Case Studies Stamp -->
-        <div class="mt-12 md:mt-16 flex justify-center">
-          <a href="#case-studies" class="group relative w-24 h-24 md:w-28 md:h-28">
-            <svg
-              viewBox="0 0 100 100"
-              class="w-full h-full text-cobalt-500 animate-spin-slow"
-              aria-hidden="true"
+          <div class="mt-10 flex flex-wrap items-center gap-4">
+            <a
+              href="#case-studies"
+              class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"
             >
-              <defs>
-                <path id="circle" d="M 50,50 m -37,0 a 37,37 0 1,1 74,0 a 37,37 0 1,1 -74,0" />
-              </defs>
-              <text
-                font-size="10"
-                fill="currentColor"
-                font-family="Manrope, sans-serif"
-                letter-spacing="1"
-              >
-                <textPath href="#circle">case studies • case studies •</textPath>
-              </text>
-            </svg>
-            <!-- Arrow pointing down -->
-            <div class="absolute inset-0 flex items-center justify-center">
-              <svg
-                viewBox="0 0 24 24"
-                class="w-6 h-6 text-cobalt-500 group-hover:translate-y-1 transition-transform"
-                aria-hidden="true"
-              >
-                <path
-                  d="M12 5v14M5 12l7 7 7-7"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
+              View case studies
+            </a>
+            <router-link
+              to="/contact"
+              class="inline-flex items-center justify-center border border-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+            >
+              Start a conversation
+            </router-link>
+          </div>
+
+          <div class="mt-12 grid gap-4 sm:grid-cols-3">
+            <div class="panel-surface p-5">
+              <p class="editorial-kicker mb-2">based in</p>
+              <p class="text-xl font-medium text-cobalt-500 dark:text-cobalt-200">
+                Palma de Mallorca
+              </p>
             </div>
-          </a>
+            <div class="panel-surface p-5">
+              <p class="editorial-kicker mb-2">focus</p>
+              <p class="text-xl font-medium text-cobalt-500 dark:text-cobalt-200">
+                Product UI + design systems
+              </p>
+            </div>
+            <div class="panel-surface p-5">
+              <p class="editorial-kicker mb-2">toolkit</p>
+              <p class="text-xl font-medium text-cobalt-500 dark:text-cobalt-200">
+                Vue, React, Nuxt, TypeScript
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <aside class="panel-surface relative overflow-hidden rounded-[2rem] p-6 md:p-8">
+          <p class="editorial-kicker mb-4">why teams bring me in</p>
+          <div class="space-y-5">
+            <div>
+              <p class="text-4xl font-display text-cobalt-500 dark:text-cobalt-200">6+</p>
+              <p
+                class="mt-1 text-sm uppercase tracking-[0.24em] text-cobalt-500/70 dark:text-cobalt-300/70"
+              >
+                years building product UI
+              </p>
+            </div>
+            <div class="editorial-rule"></div>
+            <ul class="space-y-3 text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/75">
+              <li>Complex frontend systems without enterprise bloat.</li>
+              <li>Interfaces with clear hierarchy, credible polish, and strong usability.</li>
+              <li>Case studies that prove range: commerce, maps, component libraries.</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section
+      class="border-y border-cobalt-500/12 bg-cobalt-500/[0.03] py-4 dark:border-cobalt-300/12 dark:bg-cobalt-300/[0.04]"
+    >
+      <Marquee :duration="24" pause-on-hover>
+        <div
+          class="flex items-center gap-4 pr-8 text-sm uppercase tracking-[0.22em] text-cobalt-500 dark:text-cobalt-200"
+        >
+          <span>Selected work</span>
+          <span aria-hidden="true">✦</span>
+          <span>Product UI</span>
+          <span aria-hidden="true">✦</span>
+          <span>Design Systems</span>
+          <span aria-hidden="true">✦</span>
+          <span>Frontend Architecture</span>
+          <span aria-hidden="true">✦</span>
+        </div>
+      </Marquee>
+    </section>
+
+    <section id="case-studies" class="px-6 py-14 md:px-10 md:py-20 lg:px-12">
+      <div class="mx-auto max-w-7xl">
+        <div class="mb-10 grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-end">
+          <div>
+            <p class="editorial-kicker mb-3">selected case studies</p>
+            <h2
+              class="max-w-3xl text-4xl font-display text-cobalt-500 dark:text-cobalt-200 md:text-6xl"
+            >
+              Proof first. Three projects that show how I think, ship, and refine.
+            </h2>
+          </div>
+          <p
+            class="max-w-xl text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/75 md:text-lg lg:justify-self-end"
+          >
+            Each project highlights a different strength: product complexity, system design, or UI
+            architecture. Fast scan on top. Deep dive if you want the engineering decisions.
+          </p>
+        </div>
+
+        <div class="space-y-5">
+          <CaseStudyListItem
+            v-for="(project, index) in featuredProjects"
+            :key="project.caseStudy?.slug || project.id"
+            :number="index + 1"
+            :title="project.title"
+            :slug="project.caseStudy!.slug"
+            :tags="project.tech.slice(0, 4)"
+            :image="project.caseStudy?.image || ''"
+            :description="project.description"
+            :github="project.github"
+          />
         </div>
       </div>
     </section>
-    <!-- Case Studies Section -->
-    <section id="case-studies" class="py-10 md:py-16 px-6 lg:px-12">
-      <div class="max-w-6xl mx-auto">
-        <h2 class="text-lg font-display text-cobalt-500 lowercase mb-8 px-4">case studies</h2>
 
-        <CaseStudyListItem
-          v-for="(project, index) in caseStudies"
-          :key="project.slug"
-          :number="index + 1"
-          :title="project.title"
-          :slug="project.slug"
-          :tags="project.tags"
-          :image="project.image"
-          :description="project.description"
-        />
+    <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <div class="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+        <div class="panel-surface rounded-[2rem] p-6 md:p-8">
+          <p class="editorial-kicker mb-3">beyond the featured work</p>
+          <h3 class="text-3xl font-display text-cobalt-500 dark:text-cobalt-200 md:text-4xl">
+            More repos, more experiments, more proof of range.
+          </h3>
+          <p
+            class="mt-4 max-w-2xl text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/75"
+          >
+            Smaller builds cover inventory tools, job boards, starter templates, automation work,
+            and dashboard-style products.
+          </p>
+        </div>
+
+        <a
+          href="https://github.com/caraseli02?tab=repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center border border-cobalt-500 px-6 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+        >
+          Browse GitHub ↗
+        </a>
       </div>
     </section>
 
-    <!-- Footer -->
     <Footer />
   </div>
 </template>
 
 <script setup lang="ts">
-import TextRotator from "../components/ui/TextRotator.vue";
-import CaseStudyListItem from "../components/case-study/CaseStudyListItem.vue";
 import Footer from "../components/layout/Footer.vue";
-
-interface CaseStudy {
-  title: string;
-  slug: string;
-  tags: string[];
-  image: string;
-  description: string;
-}
-
-const caseStudies: CaseStudy[] = [
-  {
-    title: "Top Properties",
-    slug: "topproperties",
-    tags: ["React 18", "TypeScript", "Leaflet"],
-    image: "/project-images/topproperties.jpg",
-    description: "Luxury real estate browser with interactive map and multi-currency pricing",
-  },
-  {
-    title: "ECAS",
-    slug: "ecas",
-    tags: ["Nuxt 3", "Stripe", "Firebase"],
-    image: "/project-images/ecas.jpg",
-    description: "Full e-commerce platform with smart pricing engine and admin dashboard",
-  },
-  {
-    title: "ABS Storybook",
-    slug: "abs-storybook",
-    tags: ["React 19", "Storybook 10", "Chromatic"],
-    image: "/project-images/abs-storybook.jpg",
-    description: "Hotel booking component library with enforced UI/business logic separation",
-  },
-];
+import Marquee from "../components/ui/Marquee.vue";
+import CaseStudyListItem from "../components/case-study/CaseStudyListItem.vue";
+import { featuredProjects } from "../data/projects";
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import { getProjectBySlug } from "../data/projects";
 
 const routes: RouteRecordRaw[] = [
   {
@@ -6,9 +7,9 @@ const routes: RouteRecordRaw[] = [
     name: "home",
     component: () => import("../pages/Home.vue"),
     meta: {
-      title: "Vlad Caraseli | Vue.js Developer",
+      title: "Vlad Caraseli | Frontend Engineer for Product Teams",
       description:
-        "Vue.js web developer based in Palma de Mallorca, building modern web applications with Vue 3, TypeScript, and Tailwind CSS.",
+        "Frontend engineer building polished product interfaces, design systems, and high-trust web experiences with Vue, React, TypeScript, and Nuxt.",
     },
   },
   {
@@ -18,7 +19,8 @@ const routes: RouteRecordRaw[] = [
     props: true,
     meta: {
       title: "Case Study | Vlad Caraseli",
-      description: "Detailed case study of a web development project.",
+      description:
+        "Deep dives into frontend engineering, interface architecture, and product-facing UI systems.",
     },
   },
   {
@@ -26,8 +28,9 @@ const routes: RouteRecordRaw[] = [
     name: "about",
     component: () => import("../pages/About.vue"),
     meta: {
-      title: "About | Vlad Caraseli",
-      description: "Learn more about Vlad Caraseli, a Vue.js developer based in Palma de Mallorca.",
+      title: "About Vlad Caraseli | Frontend Engineer",
+      description:
+        "Learn how Vlad Caraseli approaches product UI, design systems, and frontend engineering from Palma de Mallorca.",
     },
   },
   {
@@ -35,8 +38,9 @@ const routes: RouteRecordRaw[] = [
     name: "contact",
     component: () => import("../pages/Contact.vue"),
     meta: {
-      title: "Contact | Vlad Caraseli",
-      description: "Get in touch with Vlad Caraseli for web development projects.",
+      title: "Contact Vlad Caraseli | Product UI & Frontend",
+      description:
+        "Get in touch with Vlad Caraseli for frontend builds, design systems, and product-facing interface work.",
     },
   },
   {
@@ -45,10 +49,9 @@ const routes: RouteRecordRaw[] = [
     component: () => import("../pages/Extra.vue"),
     meta: {
       title: "Extra | Vlad Caraseli",
-      description: "Additional projects and experiments.",
+      description: "Additional experiments, side projects, and interface explorations.",
     },
   },
-  // Redirect old /projects route to home with anchor
   {
     path: "/projects",
     redirect: { name: "home", hash: "#case-studies" },
@@ -59,6 +62,7 @@ const routes: RouteRecordRaw[] = [
     component: () => import("../pages/NotFound.vue"),
     meta: {
       title: "404 | Vlad Caraseli",
+      description: "Page not found.",
     },
   },
 ];
@@ -69,7 +73,6 @@ const router = createRouter({
   scrollBehavior(to, _from, savedPosition) {
     if (savedPosition) return savedPosition;
 
-    // Handle anchor links
     if (to.hash) {
       return {
         el: to.hash,
@@ -81,12 +84,39 @@ const router = createRouter({
   },
 });
 
-// Update document title based on route meta
+const ensureMetaDescription = (): HTMLMetaElement => {
+  let tag = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.name = "description";
+    document.head.appendChild(tag);
+  }
+
+  return tag;
+};
+
 router.beforeEach((to, _from, next) => {
-  const title = to.meta.title as string | undefined;
+  let title = to.meta.title as string | undefined;
+  let description = to.meta.description as string | undefined;
+
+  if (to.name === "case-study" && typeof to.params.slug === "string") {
+    const project = getProjectBySlug(to.params.slug);
+
+    if (project?.caseStudy) {
+      title = `${project.title} Case Study | Vlad Caraseli`;
+      description = `${project.description} Built with ${project.tech.slice(0, 3).join(", ")} and documented as a product-focused frontend case study.`;
+    }
+  }
+
   if (title) {
     document.title = title;
   }
+
+  if (description) {
+    ensureMetaDescription().content = description;
+  }
+
   next();
 });
 


### PR DESCRIPTION
## Summary
- sharpen the homepage hero, proof, and CTA structure for faster hiring-manager comprehension
- redesign the home/about/contact flow with a stronger editorial visual direction
- improve metadata and README positioning so the portfolio better reflects broader frontend/product work

## Design direction
This pass was guided by Anthropic's `frontend-design` skill:
https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md

Applied principles from that skill:
- commit to a bold editorial direction instead of a generic portfolio layout
- use more distinctive typography and stronger visual hierarchy
- make the proof memorable and easier to scan
- keep the implementation production-grade and functional

## What changed
- home hero now leads with a clearer value proposition, stronger CTA, and product-facing positioning
- featured case studies were rebuilt into larger proof-first cards with visible source links
- about page was rewritten into shorter, more scannable positioning blocks
- contact page now frames outreach around project fit and leverage
- footer now reinforces availability and key profile signals
- route titles + meta descriptions now better reflect frontend/product breadth
- README replaced the starter-template copy with repo-specific documentation

## Validation
- `pnpm build`
- manual browser review on `/`, `/about`, `/contact`, and `/projects/topproperties`
