### PR TITLE
refactor: tighten typography on latest portfolio main

### DIFF
--- a/src/components/case-study/CaseStudyListItem.vue
+++ b/src/components/case-study/CaseStudyListItem.vue
@@ -13,7 +13,7 @@
     >
       <div class="flex items-start gap-4 md:block md:pr-3">
         <span
-          class="block text-4xl md:text-5xl lg:text-6xl font-display text-cobalt-500 leading-none tabular-nums"
+          class="block text-4xl md:text-5xl lg:text-6xl font-display font-medium tracking-[-0.04em] text-cobalt-500 leading-none tabular-nums"
         >
           {{ formattedNumber }}
         </span>
@@ -22,7 +22,9 @@
 
       <div class="min-w-0 space-y-4" :class="reverse ? 'md:order-3' : 'md:order-2'">
         <div>
-          <h3 class="text-2xl md:text-3xl font-semibold text-cobalt-500 dark:text-cobalt-200">
+          <h3
+            class="text-2xl md:text-3xl font-display leading-[0.96] text-cobalt-500 dark:text-cobalt-200"
+          >
             {{ title }}
           </h3>
           <p class="mt-3 max-w-2xl text-base md:text-lg text-cobalt-600 dark:text-cobalt-100/86">

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -73,10 +73,10 @@
         <div class="editorial-rule"></div>
 
         <div
-          class="flex items-center justify-between gap-4 text-sm text-cobalt-500/65 dark:text-cobalt-100/62"
+          class="flex items-center justify-between gap-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-cobalt-500/65 dark:text-cobalt-100/62"
         >
-          <span class="lowercase font-medium">vlad caraseli © {{ year }}</span>
-          <span class="uppercase tracking-[0.2em]">palma de mallorca</span>
+          <span>vlad caraseli © {{ year }}</span>
+          <span>palma de mallorca</span>
         </div>
       </div>
     </div>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -11,7 +11,7 @@
           aria-label="Home"
         >
           <span
-            class="text-2xl font-display font-bold text-cobalt-500 dark:text-cobalt-300 lowercase group-hover:opacity-70 transition-opacity"
+            class="text-2xl font-display font-medium tracking-[-0.04em] text-cobalt-500 dark:text-cobalt-300 lowercase group-hover:opacity-70 transition-opacity"
             >vlad</span
           >
         </router-link>
@@ -22,7 +22,7 @@
             v-for="link in navLinks"
             :key="link.path"
             :to="link.path"
-            class="inline-flex items-center min-h-[44px] text-cobalt-500 dark:text-cobalt-300 hover:text-cobalt-700 dark:hover:text-cobalt-100 text-base font-normal lowercase relative transition-colors pb-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 dark:focus-visible:outline-cobalt-300 focus-visible:outline-offset-4 rounded-sm"
+            class="relative inline-flex min-h-[44px] items-center pb-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-cobalt-500 transition-colors hover:text-cobalt-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-4 rounded-sm dark:text-cobalt-300 dark:hover:text-cobalt-100"
             :class="{ 'border-b-2 border-cobalt-500 dark:border-cobalt-300': isActive(link.path) }"
             :aria-current="isActive(link.path) ? 'page' : undefined"
           >

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -88,31 +88,19 @@
                 <p class="editorial-kicker mb-5">project facts</p>
                 <dl class="space-y-4">
                   <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
-                    <dt
-                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/72"
-                    >
-                      duration
-                    </dt>
+                    <dt class="editorial-kicker">duration</dt>
                     <dd class="mt-1 text-2xl font-display text-charcoal dark:text-cobalt-100">
                       {{ caseStudy.duration }}
                     </dd>
                   </div>
                   <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
-                    <dt
-                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/72"
-                    >
-                      role
-                    </dt>
+                    <dt class="editorial-kicker">role</dt>
                     <dd class="mt-1 text-lg text-charcoal-200 dark:text-cobalt-100/90">
                       {{ caseStudy.role }}
                     </dd>
                   </div>
                   <div class="border-b border-cobalt-500/10 pb-4 dark:border-cobalt-300/12">
-                    <dt
-                      class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/72"
-                    >
-                      year
-                    </dt>
+                    <dt class="editorial-kicker">year</dt>
                     <dd class="mt-1 text-lg text-charcoal-200 dark:text-cobalt-100/90">
                       {{ caseStudy.year }}
                     </dd>


### PR DESCRIPTION
## Summary
- recreate the typography pass cleanly from the current `origin/main` instead of the stale branch used in PR #29
- tighten header, case-study list, footer, and case-study metadata typography for better hierarchy and consistency
- keep the current latest portfolio structure intact while refining only typography details

## Test Plan
- [x] `pnpm build`
- [x] Manual browser sanity-check on Home and case study page

## Notes for Reviewers
- this replaces the stale-branch attempt from #29
- changes are intentionally small and scoped to typography consistency on top of the latest main