### PR TITLE
fix: align portfolio content with CV

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Vlad Caraseli is a frontend engineer building polished product interfaces, design systems, and high-trust web experiences with Vue, React, TypeScript, and Nuxt."
+      content="Vlad Caraseli is a frontend engineer with 4+ years of experience building polished product interfaces, design systems, and high-trust web experiences with Vue, React, TypeScript, Nuxt, and an AI-native workflow (Claude Code & Codex)."
     />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Vlad Caraseli | Frontend Engineer for Product Teams" />
     <meta
       property="og:description"
-      content="Frontend engineer building polished product interfaces, design systems, and high-trust web experiences with Vue, React, TypeScript, and Nuxt."
+      content="Frontend engineer with 4+ years building polished product interfaces, design systems, and high-trust web experiences with an AI-native workflow."
     />
     <meta property="og:url" content="https://vladcaraseli.com" />
     <meta
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="Vlad Caraseli | Frontend Engineer for Product Teams" />
     <meta
       name="twitter:description"
-      content="Frontend engineer building polished product interfaces, design systems, and high-trust web experiences."
+      content="Frontend engineer with 4+ years building polished product interfaces, design systems, and high-trust web experiences with an AI-native workflow."
     />
     <title>Vlad Caraseli | Frontend Engineer for Product Teams</title>
   </head>

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -22,7 +22,7 @@
           </div>
           <div class="mt-8 flex flex-wrap gap-3">
             <a
-              href="https://linkedin.com/in/vlad-caraseli"
+              href="https://linkedin.com/in/caraseli"
               target="_blank"
               rel="noopener noreferrer"
               class="inline-flex items-center justify-center bg-white px-5 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-cobalt-700 transition-opacity hover:opacity-85"
@@ -56,7 +56,7 @@
               GitHub ↗
             </a>
             <a
-              href="https://linkedin.com/in/vlad-caraseli"
+              href="https://linkedin.com/in/caraseli"
               target="_blank"
               rel="noopener noreferrer"
               class="ink-link"

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -16,7 +16,8 @@
           >
             Born in Moldova, now based in Palma de Mallorca. I build frontend systems that stay calm
             under complexity — commerce flows, dashboard interfaces, component libraries, and the UI
-            layers teams actually rely on.
+            layers teams actually rely on. AI-native workflow with Claude Code and Codex baked into
+            every project cycle.
           </p>
         </div>
 
@@ -41,8 +42,20 @@
                 specialty
               </p>
               <p class="mt-1">
-                Frontend architecture, UX clarity, design systems, and product-facing
-                implementation.
+                Frontend architecture, UX clarity, design systems, AI-powered development, and
+                product-facing implementation.
+              </p>
+            </div>
+            <div class="editorial-rule"></div>
+            <div>
+              <p
+                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-100/70"
+              >
+                languages
+              </p>
+              <p class="mt-1">
+                Moldovan (native) · Russian (full professional) · English (professional working) ·
+                Spanish (professional working)
               </p>
             </div>
             <div class="editorial-rule"></div>
@@ -72,8 +85,8 @@
         <article class="panel-surface p-6">
           <p class="editorial-kicker mb-3">02 — how I work</p>
           <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
-            Design-minded engineering: thoughtful systems, clean implementation, and enough visual
-            restraint that the important moments hit harder.
+            AI-native engineering: Claude Code and Codex in the dev cycle, thoughtful systems, clean
+            implementation, and enough visual restraint that the important moments hit harder.
           </p>
         </article>
         <article class="panel-surface p-6">
@@ -85,62 +98,129 @@
         </article>
       </section>
 
+      <!-- Work Experience -->
+      <section class="reveal mt-16">
+        <p class="editorial-kicker mb-6">experience</p>
+        <div class="space-y-6">
+          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+            <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
+              <div>
+                <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">
+                  Hotelverse
+                </h3>
+                <p
+                  class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/70 mt-1"
+                >
+                  UI/UX Engineer
+                </p>
+              </div>
+              <p class="text-sm text-cobalt-500/60 dark:text-cobalt-100/60">
+                Nov 2024 — Dec 2025 · Palma, Spain
+              </p>
+            </div>
+            <p class="text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
+              Architected complex UI flows using React and TypeScript, ensuring pixel-perfect
+              execution of Figma designs. Focused on performance optimization and creating highly
+              reusable UI patterns to streamline future development.
+            </p>
+          </div>
+
+          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+            <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
+              <div>
+                <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">Nezo Hub</h3>
+                <p
+                  class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/70 mt-1"
+                >
+                  Senior Frontend Engineer
+                </p>
+              </div>
+              <p class="text-sm text-cobalt-500/60 dark:text-cobalt-100/60">Apr 2023 — Oct 2024</p>
+            </div>
+            <p class="text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
+              Developed and maintained core features for a SaaS platform using Vue 3 + TypeScript.
+              Integrated custom UI components with backend APIs, collaborated on high-level
+              architectural decisions, and conducted thorough code reviews.
+            </p>
+          </div>
+
+          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+            <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
+              <div>
+                <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">
+                  Freelance — Skipso, Santandreatopproperties, Kassebil, Moonflow Club
+                </h3>
+                <p
+                  class="text-sm uppercase tracking-[0.18em] text-cobalt-500/70 dark:text-cobalt-100/70 mt-1"
+                >
+                  Frontend Developer
+                </p>
+              </div>
+              <p class="text-sm text-cobalt-500/60 dark:text-cobalt-100/60">Sep 2021 — Apr 2023</p>
+            </div>
+            <p class="text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
+              Collaborated with diverse teams to conceptualize and design reusable Vue.js
+              components, ensuring consistent quality and adherence to coding standards across
+              multiple client projects.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Education & Certifications -->
       <section
         class="reveal mt-16 grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-start"
       >
         <div>
-          <p class="editorial-kicker mb-4">working style</p>
-          <h2 class="text-3xl font-display text-cobalt-500 dark:text-cobalt-200 md:text-4xl">
-            I care about interfaces that earn trust fast.
-          </h2>
-          <div
-            class="mt-6 space-y-5 text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85"
-          >
-            <p>
-              That usually means fewer gimmicks, stronger copy hierarchy, and components that feel
-              like they belong to the same product universe.
-            </p>
-            <p>
-              I enjoy the work between “looks good” and “actually holds up” — accessibility,
-              resilience, edge states, motion restraint, and making dense product logic feel
-              legible.
-            </p>
+          <p class="editorial-kicker mb-4">education</p>
+          <div class="space-y-5">
+            <div>
+              <h3 class="text-xl font-display text-cobalt-500 dark:text-cobalt-200">Vue School</h3>
+              <p class="text-sm text-cobalt-600 dark:text-cobalt-100/80">
+                Mastering Web Application Development with Vue.js
+              </p>
+            </div>
+            <div>
+              <h3 class="text-xl font-display text-cobalt-500 dark:text-cobalt-200">Vue Mastery</h3>
+              <p class="text-sm text-cobalt-600 dark:text-cobalt-100/80">
+                From Vue.js Basics to Deep Dive
+              </p>
+            </div>
+            <div>
+              <h3 class="text-xl font-display text-cobalt-500 dark:text-cobalt-200">
+                DesignCourse
+              </h3>
+              <p class="text-sm text-cobalt-600 dark:text-cobalt-100/80">
+                Foundations of UI/UX Design, HTML/CSS
+              </p>
+            </div>
           </div>
         </div>
 
         <div class="border border-cobalt-500/15 p-6 md:p-8">
-          <p class="editorial-kicker mb-5">good fit projects</p>
-          <div class="space-y-4 text-cobalt-600 dark:text-cobalt-100/85">
-            <div>
-              <p
-                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-100/70"
-              >
-                product UI
-              </p>
-              <p class="mt-1 text-lg">Dashboards, commerce flows, account areas, internal tools.</p>
-            </div>
-            <div>
-              <p
-                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-100/70"
-              >
-                systems
-              </p>
-              <p class="mt-1 text-lg">
-                Component libraries, design systems, typed frontend architecture.
-              </p>
-            </div>
-            <div>
-              <p
-                class="text-sm uppercase tracking-[0.22em] text-cobalt-500/70 dark:text-cobalt-100/70"
-              >
-                polish
-              </p>
-              <p class="mt-1 text-lg">
-                UX cleanup, visual hierarchy, interaction refinement, and handoff-ready frontend
-                implementation.
-              </p>
-            </div>
-          </div>
+          <p class="editorial-kicker mb-5">certifications</p>
+          <ul class="space-y-3 text-cobalt-600 dark:text-cobalt-100/85">
+            <li class="flex items-start gap-2">
+              <span class="text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">✓</span>
+              <span>Certified Nuxt Master</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">✓</span>
+              <span>Certified Pinia Master</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">✓</span>
+              <span>Certified Web Professional — Site Designer (CWP)</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">✓</span>
+              <span>Advanced Frontend Course Completion</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-cobalt-500/50 dark:text-cobalt-300/50 mt-1">✓</span>
+              <span>UI/UX Course</span>
+            </li>
+          </ul>
         </div>
       </section>
     </div>
@@ -159,8 +239,18 @@ useJsonLd({
   name: "Vlad Caraseli",
   jobTitle: "Frontend Engineer",
   url: "https://vladcaraseli.com",
-  sameAs: ["https://github.com/caraseli02", "https://linkedin.com/in/vlad-caraseli"],
-  knowsAbout: ["Vue", "React", "TypeScript", "Nuxt", "Design Systems", "Frontend Architecture"],
+  sameAs: ["https://github.com/caraseli02", "https://linkedin.com/in/caraseli"],
+  knowsAbout: [
+    "Vue",
+    "React",
+    "TypeScript",
+    "Nuxt",
+    "Design Systems",
+    "Frontend Architecture",
+    "AI-Powered Development",
+    "Claude Code",
+    "Codex",
+  ],
   address: {
     "@type": "PostalAddress",
     addressLocality: "Palma de Mallorca",

--- a/src/pages/Contact.vue
+++ b/src/pages/Contact.vue
@@ -37,7 +37,7 @@
 
         <div class="mt-10 flex flex-wrap items-center gap-4">
           <a
-            href="https://linkedin.com/in/vlad-caraseli"
+            href="https://linkedin.com/in/caraseli"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -37,8 +37,8 @@
           <p
             class="mt-6 max-w-2xl text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85 md:text-xl"
           >
-            Product frontend for teams that need sharper UX, cleaner systems, and case-study-worthy
-            execution across Vue, React, Nuxt, and TypeScript.
+            Frontend engineer with 4+ years shipping product UI — Vue, React, Nuxt, TypeScript, and
+            an AI-native workflow with Claude Code and Codex.
           </p>
 
           <dl
@@ -46,7 +46,7 @@
           >
             <div class="flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">experience</dt>
-              <dd class="text-sm font-semibold tracking-[0.12em]">06 yrs</dd>
+              <dd class="text-sm font-semibold tracking-[0.12em]">04+ yrs</dd>
             </div>
             <div class="flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">stack</dt>
@@ -54,7 +54,9 @@
             </div>
             <div class="flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">shipped</dt>
-              <dd class="text-sm font-semibold tracking-[0.12em]">topproperties · ecas · abs</dd>
+              <dd class="text-sm font-semibold tracking-[0.12em]">
+                Hotelverse · Nezo Hub · Skipso
+              </dd>
             </div>
             <div class="flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">repos</dt>
@@ -100,8 +102,8 @@
           <p class="editorial-kicker mb-4">why teams bring me in</p>
           <ul class="space-y-4 text-base leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
             <li>Complex frontend systems without enterprise bloat.</li>
+            <li>AI-native workflow: Claude Code and Codex integrated into the dev cycle.</li>
             <li>Interfaces with clear hierarchy, credible polish, and strong usability.</li>
-            <li>Case studies that prove range: commerce, maps, component libraries.</li>
           </ul>
           <div
             class="mt-6 border-t border-cobalt-500/12 pt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-cobalt-500/60 dark:border-cobalt-300/12 dark:text-cobalt-200/70"
@@ -239,7 +241,7 @@ useJsonLd({
   name: "Vlad Caraseli",
   url: "https://vladcaraseli.com",
   description:
-    "Frontend engineer building polished product interfaces, design systems, and high-trust web experiences.",
+    "Frontend engineer building polished product interfaces, design systems, and high-trust web experiences with an AI-native workflow.",
   author: {
     "@type": "Person",
     name: "Vlad Caraseli",


### PR DESCRIPTION
## Summary

Revises all portfolio content to match **Vlad_CV.pdf** as source of truth. Design direction preserved — content-only changes.

## Changes

### Hard facts corrected
- **Experience**: `06 yrs` → `04+ yrs` (CV: Sep 2021–Dec 2025)
- **Shipped**: `topproperties · ecas · abs` → `Hotelverse · Nezo Hub · Skipso`
- **LinkedIn URL**: `/in/vlad-caraseli` → `/in/caraseli` (Contact, Footer, JSON-LD)

### New sections on About page
- **Work experience**: Hotelverse (UI/UX Engineer), Nezo Hub (Senior Frontend Engineer), Freelance at Skipso/Santandreatopproperties/Kassebil/Moonflow Club
- **Education**: Vue School, Vue Mastery, DesignCourse
- **Certifications**: Certified Nuxt Master, Certified Pinia Master, CWP, Advanced Frontend, UI/UX Course
- **Languages**: Moldovan (native), Russian, English, Spanish

### AI-native workflow added
- Hero subtitle mentions Claude Code & Codex
- Sidebar "why teams bring me in" updated
- About "how I work" card updated
- Meta descriptions (index.html + JSON-LD) updated

## Files changed
- `src/pages/Home.vue`
- `src/pages/About.vue`
- `src/pages/Contact.vue`
- `src/components/layout/Footer.vue`
- `index.html`