### PR TITLE
[codex] responsive portfolio adaptation

### DIFF
--- a/.agents/skills/impeccable/SKILL.md
+++ b/.agents/skills/impeccable/SKILL.md
@@ -7,22 +7,6 @@ argument-hint: "[craft|teach|extract]"
 license: Apache 2.0. Based on Anthropic's frontend-design skill. See NOTICE.md for attribution.
 ---
 
-<post-update-cleanup>
-BEFORE doing any design work, run this one-time maintenance step. Tell the user:
-
-> **Impeccable was updated.** A few skills were renamed or merged in this version (e.g. `/arrange` is now `/layout`, `/normalize` was folded into `/polish`). I'll clean up the old skill files so they don't clutter your project. This only runs once after an update.
-
-Then run:
-
-```bash
-node .agents/skills/impeccable/scripts/cleanup-deprecated.mjs
-```
-
-If the script removed files, briefly confirm what was cleaned up. If it found nothing, skip any output and move on.
-
-After running the script, delete this entire section (from `<post-update-cleanup>` through `</post-update-cleanup>` inclusive) from THIS file so it does not run again until the next update. Save the file.
-</post-update-cleanup>
-
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
 
 ## Context Gathering Protocol

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -67,6 +67,7 @@
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: clip;
   }
 
   body {
@@ -82,6 +83,7 @@
     transition:
       background-color 0.3s ease,
       color 0.3s ease;
+    overflow-x: clip;
   }
 
   .dark body {
@@ -157,7 +159,7 @@
   }
 
   .ink-link {
-    @apply inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 dark:text-cobalt-100 transition-colors hover:text-cobalt-700 dark:hover:text-white;
+    @apply inline-flex min-h-11 items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 dark:text-cobalt-100 transition-colors hover:text-cobalt-700 dark:hover:text-white;
     position: relative;
   }
 

--- a/src/components/case-study/ArchitectureDiagram.vue
+++ b/src/components/case-study/ArchitectureDiagram.vue
@@ -4,7 +4,7 @@
   >
     <!-- Top Properties -->
     <template v-if="slug === 'topproperties'">
-      <div class="grid grid-cols-3 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30">
+      <div class="grid grid-cols-1 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 sm:grid-cols-3">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">client</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Browser</p>
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div
-        class="grid grid-cols-2 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30"
+        class="grid grid-cols-1 gap-px border-t border-cobalt-500/10 bg-cobalt-500/10 dark:border-charcoal-200/30 dark:bg-charcoal-200/30 sm:grid-cols-2"
       >
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">services</p>
@@ -64,7 +64,7 @@
 
     <!-- ECAS -->
     <template v-else-if="slug === 'ecas'">
-      <div class="grid grid-cols-3 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30">
+      <div class="grid grid-cols-1 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 sm:grid-cols-3">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">frontend</p>
           <p class="text-sm font-display font-bold text-cobalt-500 dark:text-cobalt-300">Nuxt 3</p>
@@ -90,7 +90,7 @@
         </div>
       </div>
       <div
-        class="grid grid-cols-2 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30"
+        class="grid grid-cols-1 gap-px border-t border-cobalt-500/10 bg-cobalt-500/10 dark:border-charcoal-200/30 dark:bg-charcoal-200/30 sm:grid-cols-2"
       >
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">api layer</p>
@@ -122,7 +122,7 @@
 
     <!-- ABS Storybook -->
     <template v-else-if="slug === 'abs-storybook'">
-      <div class="grid grid-cols-3 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30">
+      <div class="grid grid-cols-1 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 sm:grid-cols-3">
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">
             components
@@ -152,7 +152,7 @@
         </div>
       </div>
       <div
-        class="grid grid-cols-3 gap-px bg-cobalt-500/10 dark:bg-charcoal-200/30 border-t border-cobalt-500/10 dark:border-charcoal-200/30"
+        class="grid grid-cols-1 gap-px border-t border-cobalt-500/10 bg-cobalt-500/10 dark:border-charcoal-200/30 dark:bg-charcoal-200/30 sm:grid-cols-3"
       >
         <div class="bg-cream-100 dark:bg-charcoal-50 p-4 md:p-5">
           <p class="text-xs font-mono text-cobalt-500/50 dark:text-cobalt-300/50 mb-2">types</p>

--- a/src/components/case-study/CaseStudyListItem.vue
+++ b/src/components/case-study/CaseStudyListItem.vue
@@ -1,19 +1,17 @@
 <template>
-  <article
-    class="group panel-surface relative overflow-hidden [contain:layout_style_paint] before:absolute before:inset-y-0 before:left-0 before:w-1 before:bg-cobalt-500 before:opacity-0 before:transition-opacity hover:before:opacity-100"
-  >
+  <article class="group panel-surface relative overflow-hidden [contain:layout_style_paint]">
     <router-link
       :to="{ name: 'case-study', params: { slug } }"
-      class="grid gap-6 px-5 py-6 md:px-7 md:py-8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-2"
+      class="grid min-h-12 gap-6 px-4 py-5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-2 sm:px-5 sm:py-6 md:px-7 md:py-8"
       :class="
         reverse
           ? 'md:grid-cols-[auto_minmax(0,0.95fr)_minmax(0,1.15fr)]'
           : 'md:grid-cols-[auto_minmax(0,1.3fr)_minmax(0,0.9fr)]'
       "
     >
-      <div class="flex items-start gap-4 md:block md:pr-3">
+      <div class="flex min-w-0 items-start gap-4 md:block md:pr-3">
         <span
-          class="block text-4xl md:text-5xl lg:text-6xl font-display font-medium tracking-[-0.04em] text-cobalt-500 leading-none tabular-nums"
+          class="block text-4xl font-display font-medium tracking-[-0.04em] text-cobalt-500 leading-none tabular-nums md:text-5xl lg:text-6xl"
         >
           {{ formattedNumber }}
         </span>
@@ -23,7 +21,7 @@
       <div class="min-w-0 space-y-4" :class="reverse ? 'md:order-3' : 'md:order-2'">
         <div>
           <h3
-            class="text-2xl md:text-3xl font-display leading-[0.96] text-cobalt-500 dark:text-cobalt-200"
+            class="text-2xl font-display leading-[0.98] text-cobalt-500 dark:text-cobalt-200 md:text-3xl"
           >
             {{ title }}
           </h3>
@@ -38,7 +36,7 @@
           </span>
         </div>
 
-        <div class="flex flex-wrap items-center gap-5 pt-2">
+        <div class="flex flex-wrap items-center gap-x-5 gap-y-3 pt-2">
           <span class="ink-link">
             open case study
             <span aria-hidden="true">↗</span>
@@ -49,7 +47,7 @@
             :href="github"
             target="_blank"
             rel="noopener noreferrer"
-            class="ink-link"
+            class="ink-link min-h-11"
             @click.stop
           >
             source
@@ -60,7 +58,7 @@
 
       <div
         v-if="image"
-        class="overflow-hidden rounded-[1.5rem] border border-cobalt-500/15 bg-cobalt-500/[0.04] md:self-start"
+        class="overflow-hidden rounded-2xl border border-cobalt-500/15 bg-cobalt-500/[0.04] md:self-start md:rounded-[1.5rem]"
         :class="reverse ? 'md:order-2' : 'md:order-3'"
       >
         <picture>

--- a/src/components/case-study/LessonsLearned.vue
+++ b/src/components/case-study/LessonsLearned.vue
@@ -19,7 +19,7 @@
             if (el) lessonRefs[i] = el as HTMLElement;
           }
         "
-        class="flex items-start gap-5 p-6 border border-cobalt-500/15 dark:border-charcoal-200/40 bg-cream-100 dark:bg-charcoal-50 reveal group"
+        class="reveal group flex items-start gap-3 border border-cobalt-500/15 bg-cream-100 p-4 dark:border-charcoal-200/40 dark:bg-charcoal-50 sm:gap-5 sm:p-6"
         :class="{ revealed: lessonVisibility[i] }"
         :style="{ transitionDelay: i * 100 + 'ms' }"
       >
@@ -36,7 +36,7 @@
         <div class="w-px self-stretch bg-cobalt-500/15 dark:bg-charcoal-200/30 flex-shrink-0"></div>
 
         <!-- Content -->
-        <p class="text-cobalt-700 dark:text-cobalt-100 leading-relaxed pt-1">{{ lesson }}</p>
+        <p class="pt-1 leading-relaxed text-cobalt-700 dark:text-cobalt-100">{{ lesson }}</p>
       </div>
     </div>
   </section>

--- a/src/components/case-study/OutcomesGrid.vue
+++ b/src/components/case-study/OutcomesGrid.vue
@@ -16,7 +16,7 @@
           if (el) outcomeRefs[i] = el as HTMLElement;
         }
       "
-      class="flex items-baseline gap-6 py-4 border-b border-cobalt-500/10 dark:border-charcoal-200/20 reveal group last:border-b-0"
+      class="reveal group flex flex-col gap-2 border-b border-cobalt-500/10 py-4 last:border-b-0 dark:border-charcoal-200/20 sm:flex-row sm:items-baseline sm:gap-6"
       :class="{ revealed: outcomeVisibility[i] }"
       :style="{ transitionDelay: i * 100 + 'ms' }"
     >
@@ -29,7 +29,7 @@
 
       <!-- Metric -->
       <span
-        class="text-2xl md:text-3xl font-display font-bold text-cobalt-500 dark:text-cobalt-300 shrink-0 tabular-nums w-24 md:w-32"
+        class="w-full shrink-0 font-display text-2xl font-bold tabular-nums text-cobalt-500 dark:text-cobalt-300 sm:w-24 md:w-32 md:text-3xl"
       >
         {{ outcome.metric }}
       </span>

--- a/src/components/case-study/TimelinePhaseCard.vue
+++ b/src/components/case-study/TimelinePhaseCard.vue
@@ -7,7 +7,7 @@
   >
     <!-- Phase entry -->
     <div
-      class="rounded-[1.5rem] border border-cobalt-500/12 bg-white/72 px-4 py-5 transition-colors duration-200 dark:border-cobalt-300/12 dark:bg-charcoal-50/72 md:px-5"
+      class="rounded-2xl border border-cobalt-500/12 bg-white/72 px-4 py-5 transition-colors duration-200 dark:border-cobalt-300/12 dark:bg-charcoal-50/72 md:flex md:items-start md:gap-0 md:rounded-[1.5rem] md:px-5"
       :class="{
         'shadow-[0_18px_40px_rgba(31,50,255,0.08)] ring-1 ring-cobalt-500/12 dark:ring-cobalt-300/12':
           isActive,

--- a/src/components/chat/ChatWidget.vue
+++ b/src/components/chat/ChatWidget.vue
@@ -50,7 +50,7 @@ const SUGGESTIONS = [
   <!-- Floating bubble -->
   <button
     v-if="!isOpen"
-    class="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all duration-300 hover:scale-105 cursor-pointer"
+    class="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-40 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full shadow-lg transition-all duration-300 hover:scale-105 sm:bottom-6 sm:right-6"
     style="background-color: var(--color-primary); color: white"
     aria-label="Open chat"
     @click="toggle"
@@ -75,10 +75,10 @@ const SUGGESTIONS = [
   <Transition name="slide-up">
     <div
       v-if="isOpen"
-      class="fixed z-50 flex flex-col overflow-hidden rounded-2xl shadow-2xl border"
+      class="fixed z-[90] flex flex-col overflow-hidden border shadow-2xl"
       style="background-color: var(--color-bg); border-color: var(--color-border)"
       :class="[
-        'bottom-0 right-0 w-full h-full sm:bottom-6 sm:right-6 sm:w-[400px] sm:h-auto sm:max-h-[70vh]',
+        'inset-0 h-[100dvh] w-full rounded-none sm:inset-auto sm:bottom-6 sm:right-6 sm:h-auto sm:max-h-[70vh] sm:w-[400px] sm:rounded-2xl',
       ]"
     >
       <!-- Header -->
@@ -97,7 +97,7 @@ const SUGGESTIONS = [
           >
         </div>
         <button
-          class="p-1 rounded-md transition-colors cursor-pointer"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-md transition-colors"
           style="color: var(--color-text-muted)"
           @click="toggle"
           aria-label="Close chat"
@@ -128,7 +128,7 @@ const SUGGESTIONS = [
               <button
                 v-for="suggestion in SUGGESTIONS"
                 :key="suggestion"
-                class="text-xs px-3 py-1.5 rounded-full border transition-colors cursor-pointer"
+                class="min-h-10 cursor-pointer rounded-full border px-3 py-1.5 text-xs transition-colors"
                 style="
                   border-color: var(--color-border);
                   color: var(--color-text-muted);

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -1,10 +1,10 @@
 <template>
   <footer
-    class="footer-reveal border-t border-cobalt-500/10 bg-cream-100/70 px-6 py-8 dark:bg-charcoal dark:border-cobalt-300/10"
+    class="footer-reveal border-t border-cobalt-500/10 bg-cream-100/70 px-4 py-8 dark:border-cobalt-300/10 dark:bg-charcoal sm:px-6"
   >
     <div class="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
       <div
-        class="relative overflow-hidden border border-cobalt-500/20 bg-cobalt-700 p-6 text-cream-50 shadow-[0_20px_60px_-28px_rgba(17,27,143,0.55)] md:p-8 dark:border-cobalt-300/20 dark:bg-cobalt-700"
+        class="relative overflow-hidden border border-cobalt-500/20 bg-cobalt-700 p-5 text-cream-50 shadow-[0_20px_60px_-28px_rgba(17,27,143,0.55)] dark:border-cobalt-300/20 dark:bg-cobalt-700 sm:p-6 md:p-8"
       >
         <div class="relative">
           <p class="editorial-kicker mb-3 text-cobalt-100/80">currently open to</p>
@@ -15,9 +15,11 @@
             Best fit is a team that already has momentum, but wants the interface to read as
             sharper, calmer, and more trustworthy.
           </p>
-          <div class="mt-6 flex flex-wrap items-center gap-4 text-sm text-cobalt-100/85">
+          <div
+            class="mt-6 flex flex-col gap-2 text-sm text-cobalt-100/85 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4"
+          >
             <span>Based in Palma de Mallorca</span>
-            <span aria-hidden="true">•</span>
+            <span aria-hidden="true" class="hidden sm:inline">•</span>
             <span>Vue, React, Nuxt, TypeScript</span>
           </div>
           <div class="mt-8 flex flex-wrap gap-3">
@@ -25,13 +27,13 @@
               href="https://linkedin.com/in/caraseli"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex items-center justify-center bg-white px-5 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-cobalt-700 transition-opacity hover:opacity-85"
+              class="inline-flex min-h-12 w-full items-center justify-center bg-white px-5 py-3 text-center text-xs font-semibold uppercase tracking-[0.16em] text-cobalt-700 transition-opacity hover:opacity-85 sm:w-auto sm:tracking-[0.18em]"
             >
               Start on LinkedIn ↗
             </a>
             <router-link
               to="/contact"
-              class="inline-flex items-center justify-center border border-cobalt-100/30 px-5 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-white transition-colors hover:bg-white hover:text-cobalt-700"
+              class="inline-flex min-h-12 w-full items-center justify-center border border-cobalt-100/30 px-5 py-3 text-center text-xs font-semibold uppercase tracking-[0.16em] text-white transition-colors hover:bg-white hover:text-cobalt-700 sm:w-auto sm:tracking-[0.18em]"
             >
               Contact page →
             </router-link>
@@ -39,7 +41,9 @@
         </div>
       </div>
 
-      <div class="flex flex-col justify-between gap-5 border border-cobalt-500/15 p-6 md:p-8">
+      <div
+        class="flex flex-col justify-between gap-5 border border-cobalt-500/15 p-5 sm:p-6 md:p-8"
+      >
         <div>
           <p class="editorial-kicker mb-4">find me fast</p>
           <p class="mb-5 max-w-sm text-sm leading-relaxed text-cobalt-600 dark:text-cobalt-100/80">
@@ -70,7 +74,7 @@
         <div class="editorial-rule"></div>
 
         <div
-          class="flex items-center justify-between gap-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-cobalt-500/60 dark:text-cobalt-100/60"
+          class="flex flex-col gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-cobalt-500/60 dark:text-cobalt-100/60 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:tracking-[0.2em]"
         >
           <span>vlad caraseli © {{ year }}</span>
           <span>palma de mallorca</span>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -2,8 +2,8 @@
   <header
     class="fixed top-0 left-0 right-0 z-50 bg-cream-100/95 dark:bg-charcoal/95 backdrop-blur-sm border-b border-cobalt-500/10 dark:border-charcoal-200/30"
   >
-    <div class="max-w-7xl mx-auto px-6 lg:px-12">
-      <nav class="flex items-center justify-between h-20">
+    <div class="mx-auto max-w-7xl px-4 md:px-6 lg:px-12">
+      <nav class="flex h-16 items-center justify-between md:h-20">
         <!-- Logo Mark -->
         <router-link
           to="/"
@@ -119,7 +119,7 @@
         <!-- Mobile hamburger -->
         <button
           type="button"
-          class="md:hidden w-9 h-9 flex items-center justify-center text-cobalt-500 dark:text-cobalt-300"
+          class="flex h-11 w-11 items-center justify-center border border-cobalt-500/15 text-cobalt-500 transition-colors hover:bg-cobalt-500/[0.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-cobalt-500 focus-visible:outline-offset-2 dark:border-charcoal-200/50 dark:text-cobalt-300 dark:hover:bg-cobalt-300/[0.08] md:hidden"
           :aria-label="mobileOpen ? 'Close menu' : 'Open menu'"
           :aria-expanded="mobileOpen"
           @click="mobileOpen = !mobileOpen"
@@ -157,27 +157,31 @@
     <Transition name="mobile-nav">
       <div
         v-if="mobileOpen"
-        class="fixed inset-0 top-20 z-40 bg-cream-100/98 dark:bg-charcoal/98 backdrop-blur-sm md:hidden"
+        class="absolute inset-x-0 top-full z-40 h-[calc(100dvh-4rem)] overflow-y-auto bg-cream-100/[0.98] px-4 pb-[max(2rem,env(safe-area-inset-bottom))] dark:bg-charcoal/[0.98] md:hidden"
       >
-        <nav class="flex flex-col items-center gap-6 pt-12">
+        <nav
+          class="mx-auto flex min-h-full max-w-sm flex-col items-stretch justify-center gap-3 py-8"
+        >
           <router-link
             v-for="link in navLinks"
             :key="link.path"
             :to="link.path"
-            class="text-sm font-semibold uppercase tracking-[0.2em] text-cobalt-500 dark:text-cobalt-300"
+            class="flex min-h-12 items-center justify-center border border-cobalt-500/12 px-4 text-sm font-semibold uppercase tracking-[0.2em] text-cobalt-500 transition-colors hover:bg-cobalt-500/[0.06] dark:border-cobalt-300/14 dark:text-cobalt-300 dark:hover:bg-cobalt-300/[0.08]"
+            :class="{ 'bg-cobalt-500/[0.08] dark:bg-cobalt-300/[0.1]': isActive(link.path) }"
+            :aria-current="isActive(link.path) ? 'page' : undefined"
             @click="mobileOpen = false"
           >
             {{ link.label }}
           </router-link>
 
-          <div class="flex items-center gap-3 mt-4">
+          <div class="mt-4 grid grid-cols-2 gap-3">
             <button
               type="button"
               @click="
                 $emit('open-palette');
                 mobileOpen = false;
               "
-              class="w-9 h-9 flex items-center justify-center border border-cobalt-500/20 dark:border-charcoal-200/60 text-cobalt-500 dark:text-cobalt-300"
+              class="flex min-h-12 items-center justify-center gap-2 border border-cobalt-500/20 px-4 font-mono text-[11px] uppercase tracking-[0.18em] text-cobalt-500 dark:border-charcoal-200/60 dark:text-cobalt-300"
               aria-label="Open command palette"
             >
               <svg
@@ -192,11 +196,12 @@
                 <circle cx="11" cy="11" r="7" />
                 <path d="m21 21-4.3-4.3" />
               </svg>
+              <span>cmd</span>
             </button>
 
             <button
               @click="toggle"
-              class="w-9 h-9 flex items-center justify-center border border-cobalt-500/20 dark:border-charcoal-200/60 text-cobalt-500 dark:text-cobalt-300"
+              class="flex min-h-12 items-center justify-center gap-2 border border-cobalt-500/20 px-4 font-mono text-[11px] uppercase tracking-[0.18em] text-cobalt-500 dark:border-charcoal-200/60 dark:text-cobalt-300"
               :aria-label="theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
             >
               <svg
@@ -229,6 +234,7 @@
               >
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
               </svg>
+              <span>theme</span>
             </button>
           </div>
         </nav>
@@ -238,7 +244,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, shallowRef, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useTheme } from "../../composables/useTheme";
 import { useCursorPreference } from "../../composables/useCursorPreference";
@@ -249,11 +255,10 @@ const route = useRoute();
 const { theme, toggle } = useTheme();
 const { enabled: cursorEnabled, toggle: toggleCursor } = useCursorPreference();
 
-const cursorAvailable = ref(false);
-const mobileOpen = ref(false);
+const cursorAvailable = shallowRef(false);
+const mobileOpen = shallowRef(false);
 
 // Close mobile menu on route change
-import { watch } from "vue";
 watch(route, () => {
   mobileOpen.value = false;
 });

--- a/src/components/ui/CommandPalette.vue
+++ b/src/components/ui/CommandPalette.vue
@@ -3,7 +3,7 @@
     <Transition name="palette">
       <div
         v-if="open"
-        class="fixed inset-0 z-[200] flex items-start justify-center px-4 pt-[15vh] backdrop-blur-sm"
+        class="fixed inset-0 z-[200] flex items-end justify-center px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3 backdrop-blur-sm sm:items-start sm:px-4 sm:pt-[15vh]"
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
@@ -14,7 +14,7 @@
 
         <div
           ref="panelRef"
-          class="relative w-full max-w-xl border border-cobalt-500/25 bg-cream-50 shadow-[0_30px_80px_-24px_rgba(17,27,143,0.35)] dark:border-cobalt-300/25 dark:bg-charcoal-50"
+          class="relative flex max-h-[calc(100dvh-1.5rem)] w-full max-w-xl flex-col overflow-hidden border border-cobalt-500/25 bg-cream-50 shadow-[0_30px_80px_-24px_rgba(17,27,143,0.35)] dark:border-cobalt-300/25 dark:bg-charcoal-50 sm:max-h-[70vh]"
         >
           <div
             class="flex items-center gap-3 border-b border-cobalt-500/15 px-4 py-3 dark:border-cobalt-300/15"
@@ -28,7 +28,7 @@
               v-model="query"
               type="text"
               placeholder="Jump to… case study, page, action"
-              class="flex-1 bg-transparent font-mono text-sm text-cobalt-700 placeholder:text-cobalt-500/40 focus:outline-none dark:text-cobalt-100 dark:placeholder:text-cobalt-300/40"
+              class="min-h-11 flex-1 bg-transparent font-mono text-sm text-cobalt-700 placeholder:text-cobalt-500/40 focus:outline-none dark:text-cobalt-100 dark:placeholder:text-cobalt-300/40"
               @keydown.down.prevent="move(1)"
               @keydown.up.prevent="move(-1)"
               @keydown.enter.prevent="select()"
@@ -41,13 +41,13 @@
             </kbd>
           </div>
 
-          <ul v-if="filtered.length" ref="listRef" class="max-h-[50vh] overflow-y-auto py-2">
+          <ul v-if="filtered.length" ref="listRef" class="min-h-0 flex-1 overflow-y-auto py-2">
             <li
               v-for="(item, index) in filtered"
               :key="item.id"
               :data-index="index"
               :class="[
-                'flex cursor-pointer items-center justify-between gap-3 px-4 py-2.5 font-mono text-sm transition-colors',
+                'flex min-h-12 cursor-pointer items-center justify-between gap-3 px-4 py-2.5 font-mono text-sm transition-colors',
                 index === activeIndex
                   ? 'bg-cobalt-500/10 text-cobalt-700 dark:bg-cobalt-300/12 dark:text-cobalt-100'
                   : 'text-cobalt-600 dark:text-cobalt-100/80 hover:bg-cobalt-500/5 dark:hover:bg-cobalt-300/5',
@@ -85,7 +85,7 @@
           </div>
 
           <div
-            class="flex items-center justify-between border-t border-cobalt-500/15 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-cobalt-500/55 dark:border-cobalt-300/15 dark:text-cobalt-300/55"
+            class="hidden items-center justify-between border-t border-cobalt-500/15 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-cobalt-500/55 dark:border-cobalt-300/15 dark:text-cobalt-300/55 sm:flex"
           >
             <span>↑↓ navigate</span>
             <span>↵ select</span>

--- a/src/components/ui/ShortcutLegend.vue
+++ b/src/components/ui/ShortcutLegend.vue
@@ -16,7 +16,7 @@
         ></div>
 
         <div
-          class="relative w-full max-w-md border border-cobalt-500/25 bg-cream-50 p-6 shadow-[0_30px_80px_-24px_rgba(17,27,143,0.35)] dark:border-cobalt-300/25 dark:bg-charcoal-50 md:p-7"
+          class="relative max-h-[calc(100dvh-2rem)] w-full max-w-md overflow-y-auto border border-cobalt-500/25 bg-cream-50 p-5 shadow-[0_30px_80px_-24px_rgba(17,27,143,0.35)] dark:border-cobalt-300/25 dark:bg-charcoal-50 sm:p-6 md:p-7"
         >
           <div
             class="flex items-center justify-between gap-4 border-b border-cobalt-500/15 pb-3 dark:border-cobalt-300/15"
@@ -24,7 +24,7 @@
             <p class="editorial-kicker">keyboard shortcuts</p>
             <button
               type="button"
-              class="font-mono text-[11px] uppercase tracking-[0.16em] text-cobalt-500/60 transition-colors hover:text-cobalt-700 dark:text-cobalt-300/60 dark:hover:text-cobalt-100"
+              class="inline-flex min-h-11 min-w-11 items-center justify-center font-mono text-[11px] uppercase tracking-[0.16em] text-cobalt-500/60 transition-colors hover:text-cobalt-700 dark:text-cobalt-300/60 dark:hover:text-cobalt-100"
               aria-label="Close"
               @click="$emit('close')"
             >

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="min-h-screen bg-cream-100 pt-28 dark:bg-charcoal md:pt-32">
-    <div class="mx-auto max-w-7xl px-6 pb-20 md:px-10 lg:px-12">
+  <div class="min-h-screen bg-cream-100 pt-24 dark:bg-charcoal md:pt-32">
+    <div class="mx-auto max-w-7xl px-4 pb-20 sm:px-6 md:px-10 lg:px-12">
       <section
         class="reveal-stagger grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_22rem] lg:items-start"
       >
         <div>
           <p class="editorial-kicker mb-4">about vlad caraseli</p>
           <h1
-            class="max-w-5xl text-[3.3rem] leading-[0.95] font-display text-charcoal dark:text-cobalt-100 sm:text-[4.2rem] md:text-[5.6rem]"
+            class="max-w-5xl text-[clamp(2.65rem,12vw,5.6rem)] leading-[0.95] font-display text-charcoal dark:text-cobalt-100"
           >
             I like product interfaces with strong hierarchy, useful tension, and zero fake polish.
           </h1>
@@ -21,7 +21,7 @@
           </p>
         </div>
 
-        <aside class="panel-surface rounded-[2rem] p-6 md:p-8">
+        <aside class="panel-surface rounded-2xl p-5 sm:p-6 md:rounded-[2rem] md:p-8">
           <p class="editorial-kicker mb-4">snapshot</p>
           <div class="space-y-5 text-cobalt-600 dark:text-cobalt-100/85">
             <div>
@@ -75,21 +75,21 @@
       </section>
 
       <section class="reveal mt-14 grid gap-5 md:grid-cols-3">
-        <article class="panel-surface p-6">
+        <article class="panel-surface p-5 sm:p-6">
           <p class="editorial-kicker mb-3">01 — what I do best</p>
           <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
             Turn vague product needs into sharp, production-ready interfaces with real hierarchy and
             better decision-making built into the layout.
           </p>
         </article>
-        <article class="panel-surface p-6">
+        <article class="panel-surface p-5 sm:p-6">
           <p class="editorial-kicker mb-3">02 — how I work</p>
           <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
             AI-native engineering: Claude Code and Codex in the dev cycle, thoughtful systems, clean
             implementation, and enough visual restraint that the important moments hit harder.
           </p>
         </article>
-        <article class="panel-surface p-6">
+        <article class="panel-surface p-5 sm:p-6">
           <p class="editorial-kicker mb-3">03 — where I add leverage</p>
           <p class="text-lg leading-relaxed text-cobalt-600 dark:text-cobalt-100/85">
             Complex frontends, refactors that improve trust, and design-system work that keeps teams
@@ -102,7 +102,7 @@
       <section class="reveal mt-16">
         <p class="editorial-kicker mb-6">experience</p>
         <div class="space-y-6">
-          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+          <div class="border border-cobalt-500/12 p-5 dark:border-cobalt-300/12 sm:p-6 md:p-8">
             <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
               <div>
                 <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">
@@ -125,7 +125,7 @@
             </p>
           </div>
 
-          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+          <div class="border border-cobalt-500/12 p-5 dark:border-cobalt-300/12 sm:p-6 md:p-8">
             <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
               <div>
                 <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">Nezo Hub</h3>
@@ -144,7 +144,7 @@
             </p>
           </div>
 
-          <div class="border border-cobalt-500/12 p-6 md:p-8 dark:border-cobalt-300/12">
+          <div class="border border-cobalt-500/12 p-5 dark:border-cobalt-300/12 sm:p-6 md:p-8">
             <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
               <div>
                 <h3 class="text-2xl font-display text-cobalt-500 dark:text-cobalt-200">
@@ -197,7 +197,7 @@
           </div>
         </div>
 
-        <div class="border border-cobalt-500/15 p-6 md:p-8">
+        <div class="border border-cobalt-500/15 p-5 sm:p-6 md:p-8">
           <p class="editorial-kicker mb-5">certifications</p>
           <ul class="space-y-3 text-cobalt-600 dark:text-cobalt-100/85">
             <li class="flex items-start gap-2">

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -15,7 +15,7 @@
     </div>
 
     <template v-else>
-      <section class="px-6 pb-10 pt-28 md:px-10 md:pt-36 lg:px-12">
+      <section class="px-4 pb-10 pt-24 sm:px-6 md:px-10 md:pt-36 lg:px-12">
         <div class="mx-auto max-w-7xl">
           <div class="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_20rem] lg:items-start">
             <div>
@@ -25,7 +25,7 @@
                 {{ formattedNumber }} • {{ project.category }}
               </p>
               <h1
-                class="max-w-4xl text-[3.1rem] leading-[0.92] font-display text-charcoal dark:text-cobalt-100 sm:text-[4rem] md:text-[5rem] lg:text-[5.7rem]"
+                class="max-w-4xl text-[clamp(2.65rem,12vw,5.7rem)] leading-[0.92] font-display text-charcoal dark:text-cobalt-100"
               >
                 {{ project.title }}
               </h1>
@@ -56,7 +56,7 @@
                   :href="caseStudy.liveUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"
+                  class="inline-flex min-h-12 w-full items-center justify-center bg-cobalt-500 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-white transition-opacity hover:opacity-85 sm:w-auto sm:px-6 sm:tracking-[0.18em]"
                 >
                   View live ↗
                 </a>
@@ -65,14 +65,14 @@
                   :href="project.github"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center justify-center border border-cobalt-500/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300/20 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+                  class="inline-flex min-h-12 w-full items-center justify-center border border-cobalt-500/20 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300/20 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal sm:w-auto sm:px-6 sm:tracking-[0.18em]"
                 >
                   View source ↗
                 </a>
               </div>
             </div>
 
-            <aside class="border border-cobalt-500/14 p-6 md:p-8 dark:border-cobalt-300/16">
+            <aside class="border border-cobalt-500/14 p-5 dark:border-cobalt-300/16 sm:p-6 md:p-8">
               <p
                 class="mb-5 font-mono text-[11px] uppercase tracking-[0.2em] text-cobalt-500/72 dark:text-cobalt-100/76"
               >
@@ -137,7 +137,7 @@
         </div>
       </section>
 
-      <section v-if="!heroImageFailed" class="px-6 pb-14 md:px-10 lg:px-12">
+      <section v-if="!heroImageFailed" class="px-4 pb-14 sm:px-6 md:px-10 lg:px-12">
         <div class="mx-auto max-w-7xl">
           <div
             class="overflow-hidden border border-cobalt-500/15 bg-white dark:border-cobalt-300/15 dark:bg-charcoal-50"
@@ -159,7 +159,7 @@
         </div>
       </section>
 
-      <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <section class="px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
         <div class="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
           <div>
             <p class="editorial-kicker mb-4">why this project matters</p>
@@ -202,18 +202,18 @@
         </div>
       </section>
 
-      <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <section class="px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
         <div class="mx-auto max-w-7xl">
           <p class="editorial-kicker mb-6">system view</p>
           <div
-            class="border border-cobalt-500/12 bg-white/70 p-6 dark:border-cobalt-300/12 dark:bg-charcoal-50/60 md:p-8"
+            class="overflow-hidden border border-cobalt-500/12 bg-white/70 p-4 dark:border-cobalt-300/12 dark:bg-charcoal-50/60 sm:p-6 md:p-8"
           >
             <ArchitectureDiagram :slug="slug" />
           </div>
         </div>
       </section>
 
-      <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <section class="px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
         <div
           class="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,1.1fr)_22rem] lg:items-start"
         >
@@ -223,7 +223,7 @@
 
           <aside
             v-if="caseStudy.metaphor"
-            class="relative overflow-hidden border border-cobalt-500/18 bg-cobalt-700 p-6 text-white shadow-[0_20px_60px_-28px_rgba(17,27,143,0.5)] md:p-8"
+            class="relative overflow-hidden border border-cobalt-500/18 bg-cobalt-700 p-5 text-white shadow-[0_20px_60px_-28px_rgba(17,27,143,0.5)] sm:p-6 md:p-8"
           >
             <div class="absolute inset-0 opacity-[0.08]" aria-hidden="true">
               <div class="paper-grid h-full w-full"></div>
@@ -243,7 +243,7 @@
         </div>
       </section>
 
-      <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <section class="px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
         <div class="mx-auto grid max-w-7xl gap-10 lg:grid-cols-2 lg:gap-12">
           <div>
             <OutcomesGrid :outcomes="caseStudy.outcomes" />
@@ -254,7 +254,7 @@
         </div>
       </section>
 
-      <section class="px-6 pb-16 md:px-10 lg:px-12">
+      <section class="px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
         <div class="mx-auto grid max-w-7xl gap-4 md:grid-cols-3">
           <router-link
             v-if="prevProject"
@@ -280,7 +280,7 @@
           <router-link
             v-if="nextProject"
             :to="{ name: 'case-study', params: { slug: nextProject.slug } }"
-            class="panel-surface group p-5 text-right transition-transform hover:-translate-y-1"
+            class="panel-surface group p-5 text-left transition-transform hover:-translate-y-1 md:text-right"
           >
             <p class="editorial-kicker mb-3 font-mono">next →</p>
             <p

--- a/src/pages/Contact.vue
+++ b/src/pages/Contact.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="min-h-screen bg-cream-100 dark:bg-charcoal pt-28 md:pt-32">
+  <div class="min-h-screen bg-cream-100 pt-24 dark:bg-charcoal md:pt-32">
     <div
-      class="mx-auto grid max-w-7xl gap-10 px-6 pb-20 md:px-10 lg:grid-cols-[minmax(0,1.1fr)_24rem] lg:px-12"
+      class="mx-auto grid max-w-7xl gap-10 px-4 pb-20 sm:px-6 md:px-10 lg:grid-cols-[minmax(0,1.1fr)_24rem] lg:px-12"
     >
       <section class="reveal">
         <p class="editorial-kicker mb-4">contact</p>
         <h1
-          class="max-w-4xl text-[3.2rem] leading-[0.94] font-display text-charcoal dark:text-cobalt-100 sm:text-[4.2rem] md:text-[5.4rem]"
+          class="max-w-4xl text-[clamp(2.65rem,12vw,5.4rem)] leading-[0.94] font-display text-charcoal dark:text-cobalt-100"
         >
           Bring me in when the interface needs to feel
           <span class="italic">sharper</span>, <span class="italic">clearer</span>, and harder to
@@ -40,7 +40,7 @@
             href="https://linkedin.com/in/caraseli"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"
+            class="inline-flex min-h-12 w-full items-center justify-center bg-cobalt-500 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-white transition-opacity hover:opacity-85 sm:w-auto sm:px-6 sm:tracking-[0.18em]"
           >
             Start on LinkedIn ↗
           </a>
@@ -48,14 +48,14 @@
             href="https://github.com/caraseli02?tab=repositories"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center justify-center border border-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+            class="inline-flex min-h-12 w-full items-center justify-center border border-cobalt-500 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal sm:w-auto sm:px-6 sm:tracking-[0.18em]"
           >
             Browse GitHub ↗
           </a>
         </div>
       </section>
 
-      <aside class="panel-surface rounded-[2rem] p-6 md:p-8">
+      <aside class="panel-surface rounded-2xl p-5 sm:p-6 md:rounded-[2rem] md:p-8">
         <p class="editorial-kicker mb-4">good first message</p>
         <div class="space-y-5 text-cobalt-600 dark:text-cobalt-100/85">
           <div>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="min-h-screen bg-cream-100 dark:bg-charcoal">
-    <section class="relative overflow-hidden px-6 pb-12 pt-28 md:px-10 md:pb-16 md:pt-36 lg:px-12">
-      <div class="paper-grid absolute inset-x-4 inset-y-8 rounded-2xl opacity-60"></div>
+    <section
+      class="relative overflow-hidden px-4 pb-12 pt-24 sm:px-6 md:px-10 md:pb-16 md:pt-36 lg:px-12"
+    >
+      <div
+        class="paper-grid absolute inset-x-3 inset-y-6 rounded-2xl opacity-50 sm:inset-x-4 sm:inset-y-8 sm:opacity-60"
+      ></div>
       <!-- Hero visual anchor -->
       <div class="absolute top-20 right-10 hidden lg:block" aria-hidden="true">
         <div class="relative h-72 w-72">
@@ -28,7 +32,7 @@
             <span>palma de mallorca</span>
           </p>
           <h1
-            class="max-w-4xl text-5xl leading-[0.96] font-display text-cobalt-500 dark:text-cobalt-100 sm:text-6xl md:text-[4.25rem] lg:text-[4.75rem]"
+            class="max-w-4xl text-[clamp(2.75rem,13vw,4.75rem)] leading-[0.96] font-display text-cobalt-500 dark:text-cobalt-100"
           >
             Interfaces that feel
             <span class="italic text-cobalt-400 dark:text-cobalt-200">decisive</span>
@@ -42,31 +46,33 @@
           </p>
 
           <dl
-            class="mt-10 grid grid-cols-2 gap-y-4 gap-x-6 border-y border-cobalt-500/15 py-5 font-mono text-xs uppercase tracking-[0.16em] text-cobalt-500 dark:border-cobalt-300/15 dark:text-cobalt-200 sm:grid-cols-6"
+            class="mt-10 grid grid-cols-2 gap-x-4 gap-y-4 border-y border-cobalt-500/15 py-5 font-mono text-[11px] uppercase tracking-[0.14em] text-cobalt-500 dark:border-cobalt-300/15 dark:text-cobalt-200 sm:grid-cols-3 md:gap-x-6 lg:grid-cols-6"
           >
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">experience</dt>
               <dd class="text-sm font-semibold tracking-[0.12em]">04+ yrs</dd>
             </div>
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">stack</dt>
-              <dd class="text-sm font-semibold tracking-[0.12em]">Vue · React · Nuxt · TS</dd>
+              <dd class="break-words text-sm font-semibold tracking-[0.12em]">
+                Vue · React · Nuxt · TS
+              </dd>
             </div>
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">shipped</dt>
-              <dd class="text-sm font-semibold tracking-[0.12em]">
+              <dd class="break-words text-sm font-semibold tracking-[0.12em]">
                 Hotelverse · Nezo Hub · Skipso
               </dd>
             </div>
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">repos</dt>
               <dd class="text-sm font-semibold tracking-[0.12em]">58+ public</dd>
             </div>
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">case studies</dt>
               <dd class="text-sm font-semibold tracking-[0.12em]">03 shipped</dd>
             </div>
-            <div class="flex flex-col gap-1">
+            <div class="min-w-0 flex flex-col gap-1">
               <dt class="text-cobalt-500/55 dark:text-cobalt-300/55">availability</dt>
               <dd
                 class="text-sm font-semibold tracking-[0.12em] text-cobalt-500 dark:text-cobalt-100"
@@ -83,13 +89,13 @@
           <div class="mt-10 flex flex-wrap items-center gap-4">
             <router-link
               to="/contact"
-              class="inline-flex items-center justify-center bg-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-85"
+              class="inline-flex min-h-12 w-full items-center justify-center bg-cobalt-500 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-white transition-opacity hover:opacity-85 sm:w-auto sm:px-6 sm:tracking-[0.18em]"
             >
               Start a conversation
             </router-link>
             <a
               href="#case-studies"
-              class="inline-flex items-center justify-center border border-cobalt-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+              class="inline-flex min-h-12 w-full items-center justify-center border border-cobalt-500 px-5 py-3 text-center text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal sm:w-auto sm:px-6 sm:tracking-[0.18em]"
             >
               View case studies
             </a>
@@ -114,7 +120,7 @@
       </div>
     </section>
 
-    <section id="case-studies" class="px-6 py-14 md:px-10 md:py-20 lg:px-12">
+    <section id="case-studies" class="px-4 py-14 sm:px-6 md:px-10 md:py-20 lg:px-12">
       <div class="mx-auto max-w-7xl">
         <div
           class="reveal mb-10 grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-end"
@@ -122,7 +128,7 @@
           <div>
             <p class="editorial-kicker mb-3">selected case studies</p>
             <h2
-              class="max-w-3xl text-4xl font-display text-cobalt-500 dark:text-cobalt-200 md:text-6xl"
+              class="max-w-3xl text-[clamp(2.35rem,10vw,3.75rem)] font-display leading-tight text-cobalt-500 dark:text-cobalt-200"
             >
               Proof first. Three projects that show how I think, ship, and refine.
             </h2>
@@ -153,7 +159,7 @@
       </div>
     </section>
 
-    <section class="reveal px-6 pb-16 md:px-10 lg:px-12">
+    <section class="reveal px-4 pb-16 sm:px-6 md:px-10 lg:px-12">
       <div class="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
         <div
           class="border border-cobalt-500/14 bg-white/70 p-6 dark:border-cobalt-300/14 dark:bg-charcoal-50/60 md:p-8"
@@ -216,7 +222,7 @@
             href="https://github.com/caraseli02?tab=repositories"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[9.5rem] items-end justify-between border border-cobalt-500 px-6 py-5 text-left text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+            class="inline-flex min-h-28 items-end justify-between border border-cobalt-500 px-6 py-5 text-left text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal sm:min-h-[9.5rem]"
           >
             <span>Browse GitHub</span>
             <span aria-hidden="true">↗</span>

--- a/src/pages/Projects.vue
+++ b/src/pages/Projects.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="min-h-screen bg-cream-100 dark:bg-charcoal">
-    <section class="relative overflow-hidden px-6 pb-12 pt-28 md:px-10 md:pb-16 md:pt-36 lg:px-12">
+    <section
+      class="relative overflow-hidden px-4 pb-12 pt-24 sm:px-6 md:px-10 md:pb-16 md:pt-36 lg:px-12"
+    >
       <div class="relative mx-auto max-w-7xl">
         <p class="editorial-kicker mb-5">projects index</p>
         <h1
-          class="max-w-4xl text-[3rem] leading-[0.94] font-display text-cobalt-500 dark:text-cobalt-100 sm:text-[3.8rem] md:text-[4.6rem] lg:text-[5.4rem]"
+          class="max-w-4xl text-[clamp(2.65rem,12vw,5.4rem)] leading-[0.94] font-display text-cobalt-500 dark:text-cobalt-100"
         >
           Everything I've shipped — from case-studied builds to late-night experiments.
         </h1>
@@ -16,7 +18,7 @@
         </p>
 
         <div
-          class="mt-10 flex flex-wrap items-center gap-4 font-mono text-xs tracking-[0.18em] uppercase text-cobalt-500/75 dark:text-cobalt-200/75"
+          class="mt-10 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-[0.14em] text-cobalt-500/75 dark:text-cobalt-200/75 sm:text-xs sm:tracking-[0.18em]"
         >
           <span>{{ featuredProjects.length }} case studies</span>
           <span aria-hidden="true" class="text-cobalt-500/30 dark:text-cobalt-300/30">·</span>
@@ -27,7 +29,7 @@
       </div>
     </section>
 
-    <section id="featured" class="px-6 py-14 md:px-10 md:py-20 lg:px-12">
+    <section id="featured" class="px-4 py-14 sm:px-6 md:px-10 md:py-20 lg:px-12">
       <div class="mx-auto max-w-7xl">
         <div class="mb-10 flex flex-wrap items-end justify-between gap-6">
           <div>
@@ -61,7 +63,7 @@
     </section>
 
     <section
-      class="border-y border-cobalt-500/12 bg-cream-50 px-6 py-14 md:px-10 md:py-20 lg:px-12 dark:border-cobalt-300/12 dark:bg-charcoal-50/40"
+      class="border-y border-cobalt-500/12 bg-cream-50 px-4 py-14 dark:border-cobalt-300/12 dark:bg-charcoal-50/40 sm:px-6 md:px-10 md:py-20 lg:px-12"
     >
       <div class="mx-auto max-w-7xl">
         <div class="mb-10 flex flex-wrap items-end justify-between gap-6">
@@ -117,7 +119,7 @@
       </div>
     </section>
 
-    <section class="px-6 py-20 md:px-10 md:py-28 lg:px-12">
+    <section class="px-4 py-20 sm:px-6 md:px-10 md:py-28 lg:px-12">
       <div class="mx-auto max-w-4xl text-center">
         <p class="editorial-kicker mb-4">still more</p>
         <h2
@@ -135,7 +137,7 @@
           href="https://github.com/caraseli02?tab=repositories"
           target="_blank"
           rel="noopener noreferrer"
-          class="mt-10 inline-flex items-center gap-3 border border-cobalt-500 px-8 py-4 text-sm font-semibold uppercase tracking-[0.18em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal"
+          class="mt-10 inline-flex min-h-12 w-full items-center justify-center gap-3 border border-cobalt-500 px-6 py-4 text-center text-sm font-semibold uppercase tracking-[0.16em] text-cobalt-500 transition-colors hover:bg-cobalt-500 hover:text-white dark:border-cobalt-300 dark:text-cobalt-200 dark:hover:bg-cobalt-300 dark:hover:text-charcoal sm:w-auto sm:px-8 sm:tracking-[0.18em]"
         >
           Browse all repositories
           <span aria-hidden="true">↗</span>

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,4 +13,9 @@ export default defineConfig({
     environment: "happy-dom",
   },
   plugins: [vue(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": "https://amarillo-rho.vercel.app",
+    },
+  },
 });


### PR DESCRIPTION
## Issue

The portfolio had several desktop-first surfaces that became fragile on phones and tablets: oversized editorial headings, dense monospace stat rows, multi-column case-study diagrams, full-screen overlays, and floating assistant controls all relied on layout assumptions that worked best with a wide viewport and pointer input.

For recruiters and hiring managers scanning on mobile, those constraints could make key signals harder to read quickly. For technical reviewers inspecting case studies, the dense proof surfaces risked horizontal overflow or cramped tap targets instead of feeling like deliberate editorial/terminal details.

## Cause and user impact

The root cause was not a single broken component. The responsive system had grown unevenly across route pages and overlays: header controls were sized for desktop chrome, grids switched to multi-column layouts too early, `fixed` overlays interacted poorly with the blurred fixed header, and repeated CTA/link patterns did not consistently guarantee mobile-sized touch targets.

The effect for users was a portfolio that could visually feel polished on desktop but less native on smaller screens. Important actions like opening navigation, using the command palette, browsing case-study rows, or interacting with the chat assistant needed stronger mobile and tablet behavior.

## Fix

This change applies a focused responsive adaptation pass across the portfolio:

- Tightens mobile and tablet spacing on Home, Projects, About, Contact, and Case Study pages.
- Converts large route headings to fluid `clamp()` sizing so the editorial display type keeps its identity without overflowing narrow screens.
- Makes CTA and inline-link touch targets consistently large enough for touch input.
- Reworks the mobile header menu into a full-height `100dvh` panel under the fixed header and fixes overlay stacking with the chat assistant.
- Adapts case-study architecture diagrams, outcomes, timeline cards, lessons, and list rows to stack cleanly on phones.
- Updates command palette, shortcut legend, chat panel, and footer behavior for mobile-safe sizing and safe-area spacing.
- Adds global horizontal overflow protection as a defensive guard.
- Removes the one-time post-update cleanup block from the local Impeccable skill file after running its cleanup script.
- Preserves the current Vite dev-server API proxy configuration that was present in the staged worktree.

No project-control update was needed: this does not start, complete, supersede, or reprioritize tracked roadmap work, and this repo does not currently include `docs/project-status.md`.

## Validation

- Ran `pnpm build` successfully after the implementation.
- Re-ran `pnpm build` successfully after committing and hook formatting.
- Used local headless Chrome to check `/`, `/projects`, `/about`, `/contact`, and `/projects/topproperties` at 375px, 768px, and 1440px widths.
- Confirmed no horizontal overflow on those checked routes.
- Screenshot-checked the mobile menu, command palette, and chat panel interaction states.
