### PR TITLE
perf: optimize LCP with responsive WebP sources and hover prefetching

### DIFF
--- a/src/components/case-study/CaseStudyListItem.vue
+++ b/src/components/case-study/CaseStudyListItem.vue
@@ -1,6 +1,8 @@
 <template>
   <article
     class="group panel-surface relative overflow-hidden [contain:layout_style_paint] before:absolute before:inset-y-0 before:left-0 before:w-1 before:bg-cobalt-500 before:opacity-0 before:transition-opacity hover:before:opacity-100"
+    @mouseenter="prefetchAssets"
+    @focusin="prefetchAssets"
   >
     <router-link
       :to="{ name: 'case-study', params: { slug } }"
@@ -84,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -113,4 +115,19 @@ const webpBase = computed(() => {
   if (!props.image) return "";
   return props.image.replace(/\.[^.]+$/, "");
 });
+
+const prefetched = ref(false);
+
+function prefetchAssets() {
+  if (prefetched.value || !webpBase.value) return;
+  prefetched.value = true;
+
+  // Prefetch the full desktop webp screenshot in background
+  const imgDesktop = new Image();
+  imgDesktop.src = `${webpBase.value}.webp`;
+
+  // Prefetch the tablet 640w webp screenshot in background
+  const imgTablet = new Image();
+  imgTablet.src = `${webpBase.value}-640.webp`;
+}
 </script>

--- a/src/pages/CaseStudy.vue
+++ b/src/pages/CaseStudy.vue
@@ -143,7 +143,11 @@
             class="overflow-hidden border border-cobalt-500/15 bg-white dark:border-cobalt-300/15 dark:bg-charcoal-50"
           >
             <picture>
-              <source type="image/webp" :srcset="heroWebpSrc" />
+              <source
+                type="image/webp"
+                :srcset="`${webpBase}-320.webp 320w, ${webpBase}-640.webp 640w, ${webpBase}.webp 1280w`"
+                sizes="(max-width: 640px) 320px, (max-width: 1024px) 640px, 1280px"
+              />
               <img
                 :src="heroImgSrc"
                 :alt="`${project.title} screenshot`"
@@ -320,7 +324,10 @@ const formattedNumber = computed(() => {
 });
 
 const heroImgSrc = computed(() => caseStudy.value?.image || `/project-images/${props.slug}.jpg`);
-const heroWebpSrc = computed(() => heroImgSrc.value.replace(/\.[^.]+$/, ".webp"));
+const webpBase = computed(() => {
+  if (!heroImgSrc.value) return "";
+  return heroImgSrc.value.replace(/\.[^.]+$/, "");
+});
 
 const heroOutcomes = computed(() => caseStudy.value?.outcomes.slice(0, 3) ?? []);
 const projectHighlights = computed(() => project.value?.highlights.slice(0, 4) ?? []);


### PR DESCRIPTION
This PR introduces two performance optimizations targeting the Largest Contentful Paint (LCP) metric:

1. **Responsive Hero WebP Screenshots**: Updates `CaseStudy.vue` to load optimized `-320.webp` and `-640.webp` images on smaller viewport sizes, reducing load duration.
2. **Hover/Focus Asset Prefetching**: Adds hover and keyboard focus-triggered image prefetching in `CaseStudyListItem.vue`. The browser pre-fetches the high-resolution screenshot in the background, achieving instantaneous rendering on router transition.

Verified locally with `pnpm build` and `pnpm exec vp check`.